### PR TITLE
feat: add `ls` command to list Google Slides presentations

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -1,0 +1,51 @@
+/*
+Copyright © 2025 Ken'ichiro Oyama <k1lowxb@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"github.com/k1LoW/deck/deck"
+	"github.com/spf13/cobra"
+)
+
+var lsCmd = &cobra.Command{
+	Use:   "ls",
+	Short: "list Google Slides presentations",
+	Long:  `list Google Slides presentations.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		d, err := deck.New(cmd.Context(), "")
+		if err != nil {
+			return err
+		}
+		slides, err := d.List()
+		if err != nil {
+			return err
+		}
+		for _, slide := range slides {
+			cmd.Printf("%s\t%s\n", slide.ID, slide.Title)
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(lsCmd)
+}

--- a/deck/deck.go
+++ b/deck/deck.go
@@ -46,6 +46,11 @@ type bulletRange struct {
 	end    int
 }
 
+type Slide struct {
+	ID    string
+	Title string
+}
+
 // New creates a new Deck.
 func New(ctx context.Context, id string) (*Deck, error) {
 	d := &Deck{id: id}
@@ -88,6 +93,11 @@ func New(ctx context.Context, id string) (*Deck, error) {
 		return nil, err
 	}
 	d.driveSrv = driveSrv
+
+	if id == "" {
+		return d, nil
+	}
+
 	if err := d.refresh(); err != nil {
 		return nil, err
 	}
@@ -112,6 +122,24 @@ func New(ctx context.Context, id string) (*Deck, error) {
 	}
 
 	return d, nil
+}
+
+func (d *Deck) List() ([]*Slide, error) {
+	var slides []*Slide
+
+	r, err := d.driveSrv.Files.List().Q("mimeType='application/vnd.google-apps.presentation'").Fields("files(id, name)").Do()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, f := range r.Files {
+		slides = append(slides, &Slide{
+			ID:    f.Id,
+			Title: f.Name,
+		})
+	}
+
+	return slides, nil
 }
 
 func (d *Deck) ListLayouts() []string {


### PR DESCRIPTION
This pull request introduces new functionality to list Google Slides presentations and includes several changes across multiple files to support this feature. The most important changes include adding a new command, defining a new `Slide` struct, and implementing the `List` method in the `Deck` struct.

New functionality for listing Google Slides presentations:

* [`cmd/ls.go`](diffhunk://#diff-9865f1c8ef620ff3656b04fb97f95e74a92261123bd6aa1b937e156131409ca7R1-R51): Added a new command `ls` to list Google Slides presentations. This includes the command definition and its associated logic to fetch and display the list of presentations.

Supporting changes in `deck` package:

* [`deck/deck.go`](diffhunk://#diff-65ff809baa1373e4a270791a6daba34bc71bfdc54bc35743b837451a3d17d1fbR49-R53): Defined a new `Slide` struct with `ID` and `Title` fields to represent individual slides.
* [`deck/deck.go`](diffhunk://#diff-65ff809baa1373e4a270791a6daba34bc71bfdc54bc35743b837451a3d17d1fbR96-R100): Modified the `New` function to handle the case where the `id` parameter is an empty string, allowing for the creation of a `Deck` instance without an initial presentation ID.
* [`deck/deck.go`](diffhunk://#diff-65ff809baa1373e4a270791a6daba34bc71bfdc54bc35743b837451a3d17d1fbR127-R144): Implemented the `List` method for the `Deck` struct to query and return a list of Google Slides presentations.