### PR TITLE
feat(apply): add `--title` flag to update presentation title

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -27,6 +27,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var title string
+
 var applyCmd = &cobra.Command{
 	Use:   "apply [PRESENTATION_ID] [DECK_FILE]",
 	Short: "apply desk written in markdown to Google Slides presentation",
@@ -46,10 +48,16 @@ var applyCmd = &cobra.Command{
 		if err := d.Apply(slides); err != nil {
 			return err
 		}
+		if title != "" {
+			if err := d.UpdateTitle(title); err != nil {
+				return err
+			}
+		}
 		return nil
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(applyCmd)
+	applyCmd.Flags().StringVarP(&title, "title", "t", "", "title of the presentation")
 }

--- a/deck.go
+++ b/deck.go
@@ -127,6 +127,7 @@ func New(ctx context.Context, id string) (*Deck, error) {
 	return d, nil
 }
 
+// List Google Slides presentations.
 func (d *Deck) List() ([]*Slide, error) {
 	var slides []*Slide
 
@@ -145,6 +146,7 @@ func (d *Deck) List() ([]*Slide, error) {
 	return slides, nil
 }
 
+// ListLayouts lists layouts of the presentation.
 func (d *Deck) ListLayouts() []string {
 	var layouts []string
 	for _, l := range d.presentation.Layouts {
@@ -153,6 +155,7 @@ func (d *Deck) ListLayouts() []string {
 	return layouts
 }
 
+// Apply the markdown slides to the presentation.
 func (d *Deck) Apply(slides md.Slides) error {
 	for i, page := range slides {
 		if page.Layout == "" {
@@ -177,6 +180,18 @@ func (d *Deck) Apply(slides md.Slides) error {
 	return nil
 }
 
+// UpdateTitle updates the title of the presentation.
+func (d *Deck) UpdateTitle(title string) error {
+	file := &drive.File{
+		Name: title,
+	}
+	if _, err := d.driveSrv.Files.Update(d.id, file).Do(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Export the presentation as PDF.
 func (d *Deck) Export(w io.Writer) error {
 	req, err := d.driveSrv.Files.Export(d.id, "application/pdf").Download()
 	if err != nil {


### PR DESCRIPTION
This pull request includes several changes to the `cmd/apply.go` and `deck.go` files, mainly adding new functionalities and improving the code documentation. The most important changes include the addition of a new flag for updating the presentation title, new methods for listing layouts and updating the title, and improved code comments.

New functionality and improvements:

* [`cmd/apply.go`](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fR30-R31): Added a new flag `--title` (short `-t`) to specify the title of the presentation, and updated the `applyCmd` to handle this new flag. [[1]](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fR30-R31) [[2]](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fR51-R62)
* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R183-R194): Added the `UpdateTitle` method to update the title of the presentation using the Google Drive API.

Code documentation:

* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R130): Added comments for the `List`, `ListLayouts`, `Apply`, and `Export` methods to improve code readability and maintainability. [[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R130) [[2]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R149) [[3]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R158) [[4]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R183-R194)