### PR TITLE
feat(cmd): add `new` command to create presentations

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -22,26 +22,46 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/k1LoW/deck"
 	"github.com/spf13/cobra"
 )
 
-var lsCmd = &cobra.Command{
-	Use:   "ls",
-	Short: "list Google Slides presentations",
-	Long:  `list Google Slides presentations.`,
+var from string
+
+var newCmd = &cobra.Command{
+	Use:   "new",
+	Short: "create new presentation",
+	Long:  `create new presentation.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		slides, err := deck.List(cmd.Context())
-		if err != nil {
-			return err
+		var (
+			d   *deck.Deck
+			err error
+		)
+		if from != "" {
+			d, err = deck.CreateFrom(cmd.Context(), from)
+			if err != nil {
+				return err
+			}
+		} else {
+			d, err = deck.Create(cmd.Context())
+			if err != nil {
+				return err
+			}
 		}
-		for _, slide := range slides {
-			cmd.Printf("%s\t%s\n", slide.ID, slide.Title)
+		if title != "" {
+			if err := d.UpdateTitle(title); err != nil {
+				return err
+			}
 		}
+		fmt.Println(d.ID())
 		return nil
 	},
 }
 
 func init() {
-	rootCmd.AddCommand(lsCmd)
+	rootCmd.AddCommand(newCmd)
+	newCmd.Flags().StringVarP(&title, "title", "t", "", "title of the presentation")
+	newCmd.Flags().StringVarP(&from, "from", "f", "", "presentation id that uses the theme you want to use")
 }


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and structure of the `deck` package, particularly in the creation and management of Google Slides presentations. The most important changes include the addition of new commands, refactoring of the `Deck` struct, and improvements to the initialization and refresh processes.

### Command Enhancements:
* Added a new command `new` to create a new presentation, with options to set the title and use an existing presentation as a theme. (`cmd/new.go`)

### Refactoring and Initialization:
* Refactored the `New` function to delegate initialization to a new `initialize` function and added `Create` and `CreateFrom` functions for creating presentations. (`deck.go`)
* Simplified the `ls` command by using the new `List` function from the `deck` package. (`cmd/ls.go`)

### Refresh Functionality:
* Enhanced the `refresh` method to set default layouts and ensure the presentation data is up-to-date. (`deck.go`)
* Updated the `DeletePageAfter` method to call `refresh` after deleting a page. (`deck.go`)

These changes collectively improve the usability and maintainability of the `deck` package, making it easier to create and manage Google Slides presentations programmatically.