### PR TITLE
feat: support link

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -429,10 +429,28 @@ func (d *Deck) applyPage(index int, page *md.Page) error {
 								},
 								TextRange: &slides.Range{
 									Type:       "FIXED_RANGE",
-									StartIndex: ptrInt64(int64(count)),
-									EndIndex:   ptrInt64(int64(count + flen)),
+									StartIndex: ptrInt64(int64(count + plen)),
+									EndIndex:   ptrInt64(int64(count + plen + flen)),
 								},
 								Fields: "bold",
+							},
+						})
+					}
+					if fragment.Link != "" {
+						styleReqs = append(styleReqs, &slides.Request{
+							UpdateTextStyle: &slides.UpdateTextStyleRequest{
+								ObjectId: bodies[i].objectID,
+								Style: &slides.TextStyle{
+									Link: &slides.Link{
+										Url: fragment.Link,
+									},
+								},
+								TextRange: &slides.Range{
+									Type:       "FIXED_RANGE",
+									StartIndex: ptrInt64(int64(count + plen)),
+									EndIndex:   ptrInt64(int64(count + plen + flen)),
+								},
+								Fields: "link",
 							},
 						})
 					}

--- a/testdata/slide.md
+++ b/testdata/slide.md
@@ -34,7 +34,7 @@ comment
 1. H
   2. I
 
-ref: https://github.com/k1LoW/deck
+ref: [deck repo](https://github.com/k1LoW/deck)
 
 ---
 

--- a/testdata/slide.md
+++ b/testdata/slide.md
@@ -4,7 +4,7 @@
 
 @k1LoW
 
-<!-- {"layout":"title-1"} -->
+<!-- {"layout":"title"} -->
 
 ---
 
@@ -18,21 +18,21 @@ comment
 
 <!-- comment -->
 
-<!-- {"layout":"section-1"} -->
+<!-- {"layout":"section"} -->
 
 ---
 
 # Title
 
-- A
-- **B**
-- C
-    - D
-- **E**
-    - F
-        - G
-1. H
-  2. I
+- aA
+- b**B**
+- cC
+    - dD
+- **e**E
+    - fF
+        - gG
+1. h**H**
+  2. **i**I
 
 ref: [deck repo](https://github.com/k1LoW/deck)
 
@@ -46,7 +46,7 @@ ref: [deck repo](https://github.com/k1LoW/deck)
 
 body
 
-<!-- {"layout":"title-and-body-2"} -->
+<!-- {"layout":"title-and-body"} -->
 
 ---
 
@@ -66,5 +66,5 @@ b
 
 c
 
-<!-- {"layout":"title-and-body-4"} -->
+<!-- {"layout":"title-and-body-3col"} -->
 

--- a/testdata/slide.md.golden
+++ b/testdata/slide.md.golden
@@ -123,7 +123,11 @@
           {
             "fragments": [
               {
-                "value": "ref: https://github.com/k1LoW/deck"
+                "value": "ref: "
+              },
+              {
+                "value": "deck repo",
+                "link": "https://github.com/k1LoW/deck"
               }
             ]
           }

--- a/testdata/slide.md.golden
+++ b/testdata/slide.md.golden
@@ -1,6 +1,6 @@
 [
   {
-    "layout": "title-1",
+    "layout": "title",
     "titles": [
       "Title"
     ],
@@ -22,7 +22,7 @@
     ]
   },
   {
-    "layout": "section-1",
+    "layout": "section",
     "titles": [
       "Title"
     ],
@@ -45,13 +45,16 @@
           {
             "fragments": [
               {
-                "value": "A"
+                "value": "aA"
               }
             ],
             "bullet": "-"
           },
           {
             "fragments": [
+              {
+                "value": "b"
+              },
               {
                 "value": "B",
                 "bold": true
@@ -62,7 +65,7 @@
           {
             "fragments": [
               {
-                "value": "C"
+                "value": "cC"
               }
             ],
             "bullet": "-"
@@ -70,7 +73,7 @@
           {
             "fragments": [
               {
-                "value": "D"
+                "value": "dD"
               }
             ],
             "bullet": "-",
@@ -79,8 +82,11 @@
           {
             "fragments": [
               {
-                "value": "E",
+                "value": "e",
                 "bold": true
+              },
+              {
+                "value": "E"
               }
             ],
             "bullet": "-"
@@ -88,7 +94,7 @@
           {
             "fragments": [
               {
-                "value": "F"
+                "value": "fF"
               }
             ],
             "bullet": "-",
@@ -97,7 +103,7 @@
           {
             "fragments": [
               {
-                "value": "G"
+                "value": "gG"
               }
             ],
             "bullet": "-",
@@ -106,13 +112,21 @@
           {
             "fragments": [
               {
-                "value": "H"
+                "value": "h"
+              },
+              {
+                "value": "H",
+                "bold": true
               }
             ],
             "bullet": "1"
           },
           {
             "fragments": [
+              {
+                "value": "i",
+                "bold": true
+              },
               {
                 "value": "I"
               }
@@ -136,7 +150,7 @@
     ]
   },
   {
-    "layout": "title-and-body-2",
+    "layout": "title-and-body",
     "titles": [
       "1"
     ],
@@ -159,7 +173,7 @@
     ]
   },
   {
-    "layout": "title-and-body-4",
+    "layout": "title-and-body-3col",
     "titles": [
       "1"
     ],


### PR DESCRIPTION
This pull request includes several changes to the `deck` project, focusing on adding link support to fragments and updating test data accordingly.

Enhancements to fragment handling:

* [`md/md.go`](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R41): Added a `Link` field to the `Fragment` struct and updated the `toFragments` function to handle `ast.Link` nodes, allowing fragments to include links. [[1]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R41) [[2]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R191-R209)

Updates to slide processing:

* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L432-R456): Modified the `applyPage` method to include link handling in `styleReqs` if a fragment contains a link.

Changes to test data:

* [`testdata/slide.md`](diffhunk://#diff-7e98ece8646a086225908b54073d2f9ec0ade9ee8dc56cf4050de13506786b88L7-R7): Updated layout identifiers and adjusted bullet points and references to include links. [[1]](diffhunk://#diff-7e98ece8646a086225908b54073d2f9ec0ade9ee8dc56cf4050de13506786b88L7-R7) [[2]](diffhunk://#diff-7e98ece8646a086225908b54073d2f9ec0ade9ee8dc56cf4050de13506786b88L21-R37) [[3]](diffhunk://#diff-7e98ece8646a086225908b54073d2f9ec0ade9ee8dc56cf4050de13506786b88L49-R49) [[4]](diffhunk://#diff-7e98ece8646a086225908b54073d2f9ec0ade9ee8dc56cf4050de13506786b88L69-R69)
* [`testdata/slide.md.golden`](diffhunk://#diff-5fd77e2270cf8b48654db0d5f4fb99127edb7378d2c59617089ef3f9f086cad9L3-R3): Updated expected output to reflect changes in layout identifiers, bullet points, and added link handling in fragments. [[1]](diffhunk://#diff-5fd77e2270cf8b48654db0d5f4fb99127edb7378d2c59617089ef3f9f086cad9L3-R3) [[2]](diffhunk://#diff-5fd77e2270cf8b48654db0d5f4fb99127edb7378d2c59617089ef3f9f086cad9L25-R25) [[3]](diffhunk://#diff-5fd77e2270cf8b48654db0d5f4fb99127edb7378d2c59617089ef3f9f086cad9L48-R57) [[4]](diffhunk://#diff-5fd77e2270cf8b48654db0d5f4fb99127edb7378d2c59617089ef3f9f086cad9L65-R76) [[5]](diffhunk://#diff-5fd77e2270cf8b48654db0d5f4fb99127edb7378d2c59617089ef3f9f086cad9L82-R97) [[6]](diffhunk://#diff-5fd77e2270cf8b48654db0d5f4fb99127edb7378d2c59617089ef3f9f086cad9L100-R106) [[7]](diffhunk://#diff-5fd77e2270cf8b48654db0d5f4fb99127edb7378d2c59617089ef3f9f086cad9L109-R129) [[8]](diffhunk://#diff-5fd77e2270cf8b48654db0d5f4fb99127edb7378d2c59617089ef3f9f086cad9L126-R144) [[9]](diffhunk://#diff-5fd77e2270cf8b48654db0d5f4fb99127edb7378d2c59617089ef3f9f086cad9L135-R153)