### PR TITLE
feat: add support for italic text

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -422,12 +422,13 @@ func (d *Deck) applyPage(index int, page *md.Page) error {
 			}
 			for _, fragment := range paragraph.Fragments {
 				flen := utf8.RuneCountInString(fragment.Value)
-				if fragment.Bold {
+				if fragment.Bold || fragment.Italic {
 					styleReqs = append(styleReqs, &slides.Request{
 						UpdateTextStyle: &slides.UpdateTextStyleRequest{
 							ObjectId: bodies[i].objectID,
 							Style: &slides.TextStyle{
-								Bold: true,
+								Bold:   fragment.Bold,
+								Italic: fragment.Italic,
 							},
 							TextRange: &slides.Range{
 								Type:       "FIXED_RANGE",

--- a/md/md.go
+++ b/md/md.go
@@ -38,6 +38,7 @@ type Paragraph struct {
 type Fragment struct {
 	Value         string `json:"value"`
 	Bold          bool   `json:"bold,omitempty"`
+	Italic        bool   `json:"italic,omitempty"`
 	Link          string `json:"link,omitempty"`
 	SoftLineBreak bool   `json:"softLineBreak,omitempty"`
 }
@@ -194,7 +195,8 @@ func toFragments(b []byte, n ast.Node) ([]*Fragment, error) {
 			}
 			frags = append(frags, &Fragment{
 				Value:         children[0].Value,
-				Bold:          true,
+				Bold:          (n.Level == 2),
+				Italic:        (n.Level == 1),
 				SoftLineBreak: children[0].SoftLineBreak,
 			})
 		case *ast.Link:

--- a/testdata/slide.md
+++ b/testdata/slide.md
@@ -28,7 +28,7 @@ comment
 - b**B**
 - cC
     - dD
-- **e**E
+- *e*E
     - fF
         - gG
 1. h**H**

--- a/testdata/slide.md.golden
+++ b/testdata/slide.md.golden
@@ -83,7 +83,7 @@
             "fragments": [
               {
                 "value": "e",
-                "bold": true
+                "italic": true
               },
               {
                 "value": "E"


### PR DESCRIPTION
This pull request includes several changes to add support for italic text formatting in the `Deck` application. The most important changes include updating the `Fragment` struct to include an `Italic` field, modifying the `applyPage` function to handle italic text, and updating test data to reflect these changes.

Changes to support italic text formatting:

* [`md/md.go`](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R41): Updated the `Fragment` struct to include an `Italic` field and modified the `toFragments` function to set the `Italic` property based on the node level. [[1]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R41) [[2]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L197-R199)
* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L425-R431): Modified the `applyPage` function to apply italic text styles in addition to bold styles.

Updates to test data:

* [`testdata/slide.md`](diffhunk://#diff-7e98ece8646a086225908b54073d2f9ec0ade9ee8dc56cf4050de13506786b88L31-R31): Updated test markdown data to include italic text.
* [`testdata/slide.md.golden`](diffhunk://#diff-5fd77e2270cf8b48654db0d5f4fb99127edb7378d2c59617089ef3f9f086cad9L86-R86): Updated expected output for test cases to reflect the addition of italic text formatting.