### PR TITLE
fix(deck): correct text style update logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage.out
 deck
 *.json
 *~lock~*
+.DS_Store

--- a/deck.go
+++ b/deck.go
@@ -423,6 +423,12 @@ func (d *Deck) applyPage(index int, page *md.Page) error {
 			for _, fragment := range paragraph.Fragments {
 				flen := utf8.RuneCountInString(fragment.Value)
 				if fragment.Bold || fragment.Italic {
+					var fields string
+					if fragment.Bold {
+						fields = "bold"
+					} else if fragment.Italic {
+						fields = "italic"
+					}
 					styleReqs = append(styleReqs, &slides.Request{
 						UpdateTextStyle: &slides.UpdateTextStyleRequest{
 							ObjectId: bodies[i].objectID,
@@ -435,7 +441,7 @@ func (d *Deck) applyPage(index int, page *md.Page) error {
 								StartIndex: ptrInt64(int64(count + plen)),
 								EndIndex:   ptrInt64(int64(count + plen + flen)),
 							},
-							Fields: "bold",
+							Fields: fields,
 						},
 					})
 				}


### PR DESCRIPTION
This pull request includes changes to the `applyPage` function in the `deck.go` file to improve handling of text styles. The most important changes include the introduction of a new variable to dynamically set the `Fields` value based on whether the text is bold or italic.

Improvements to text style handling:

* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R426-R431): Added a new variable `fields` to dynamically set the `Fields` value to "bold" or "italic" based on the text style of the fragment.
* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L438-R444): Updated the `Fields` assignment in the `UpdateTextStyleRequest` to use the new `fields` variable.