### PR TITLE
feat(logging): integrate slog for enhanced logging

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -22,7 +22,12 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"fmt"
+	"log/slog"
+	"os"
+
 	"github.com/k1LoW/deck"
+	"github.com/k1LoW/deck/handler/dot"
 	"github.com/k1LoW/deck/md"
 	"github.com/spf13/cobra"
 )
@@ -45,9 +50,15 @@ var applyCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		logger := slog.New(
+			dot.New(slog.NewTextHandler(os.Stdout, nil)),
+		)
+		d.SetLogger(logger)
+
 		if err := d.Apply(slides); err != nil {
 			return err
 		}
+		fmt.Println()
 		if title != "" {
 			if err := d.UpdateTitle(title); err != nil {
 				return err

--- a/deck.go
+++ b/deck.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -35,6 +36,7 @@ type Deck struct {
 	defaultTitleLayout   string
 	defaultSectionLayout string
 	defaultLayout        string
+	logger               *slog.Logger
 }
 
 type placeholder struct {
@@ -145,7 +147,9 @@ func List(ctx context.Context) ([]*Slide, error) {
 }
 
 func initialize(ctx context.Context) (*Deck, error) {
-	d := &Deck{}
+	d := &Deck{
+		logger: slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	}
 	if os.Getenv("XDG_DATA_HOME") != "" {
 		d.dataHomePath = filepath.Join(os.Getenv("XDG_DATA_HOME"), "deck")
 	} else {
@@ -269,7 +273,13 @@ func (d *Deck) Export(w io.Writer) error {
 	return nil
 }
 
+func (d *Deck) SetLogger(logger *slog.Logger) {
+	d.logger = logger
+}
+
 func (d *Deck) applyPage(index int, page *md.Page) error {
+	d.logger.Info("appling page", slog.Int("index", 0))
+	defer d.logger.Info("applied page", slog.Int("index", 0))
 	layoutMap := map[string]*slides.Page{}
 	for _, l := range d.presentation.Layouts {
 		layoutMap[l.LayoutProperties.DisplayName] = l

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/k1LoW/deck
 go 1.23.6
 
 require (
+	github.com/fatih/color v1.16.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
+	github.com/mattn/go-colorable v0.1.13
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.9.1
 	github.com/tenntenn/golden v0.5.4
@@ -28,6 +30,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/mapfs v0.0.0-20210615234106-095c008854e6 // indirect
 	github.com/josharian/txtarfs v0.0.0-20210615234325-77aca6df5bca // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,7 @@ github.com/josharian/txtarfs v0.0.0-20210615234325-77aca6df5bca h1:a8xeK4GsWLE4L
 github.com/josharian/txtarfs v0.0.0-20210615234325-77aca6df5bca/go.mod h1:UbC32ft9G/jG+sZI8wLbIBNIrYr7vp/yqMDa9SxVBNA=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -95,6 +96,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/handler/dot/dot.go
+++ b/handler/dot/dot.go
@@ -1,0 +1,45 @@
+package dot
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/mattn/go-colorable"
+)
+
+var yellow = color.New(color.FgYellow, color.Bold).SprintFunc()
+
+func New(h slog.Handler) slog.Handler {
+	return &dotHandler{
+		handler: h,
+		stdout:  colorable.NewColorableStdout(),
+	}
+}
+
+type dotHandler struct {
+	handler slog.Handler
+	stdout  io.Writer
+}
+
+func (h *dotHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.handler.Enabled(ctx, level)
+}
+
+func (h *dotHandler) Handle(ctx context.Context, r slog.Record) error {
+	if !strings.Contains(r.Message, "applied") {
+		return nil
+	}
+	h.stdout.Write([]byte(yellow(".")))
+	return nil
+}
+
+func (h *dotHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &dotHandler{handler: h.handler.WithAttrs(attrs)}
+}
+
+func (h *dotHandler) WithGroup(name string) slog.Handler {
+	return &dotHandler{handler: h.handler.WithGroup(name)}
+}


### PR DESCRIPTION
This pull request introduces logging enhancements and new dependencies to the `deck` project. The most important changes include adding structured logging using the `slog` package, creating a custom `dot` handler for logging, and updating the `go.mod` file with new dependencies.

### Logging Enhancements:

* [`cmd/apply.go`](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fR25-R30): Added structured logging with `slog` and a custom `dot` handler. The logger is initialized and set for the `Deck` instance. [[1]](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fR25-R30) [[2]](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fR53-R61)
* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R9): Introduced a `logger` field in the `Deck` struct, initialized the logger in the `initialize` function, and added a `SetLogger` method. Logging statements were added to the `applyPage` method. [[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R9) [[2]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R39) [[3]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L148-R152) [[4]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R276-R282)

### New Dependencies:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R6-R8): Added dependencies for `github.com/fatih/color`, `github.com/mattn/go-colorable`, and `github.com/mattn/go-isatty` to support the new logging functionality. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R6-R8) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R33)

### Custom Logging Handler:

* [`handler/dot/dot.go`](diffhunk://#diff-addbfc1f57ce506eabaa57742bfc6f9230832f210a82c0b47dc4bb0f1605aff6R1-R45): Implemented a custom `dotHandler` to output a dot for each "applied" log message. This handler uses color formatting for better visibility in the terminal.