### PR TITLE
fix(deck): increase retry limits for HTTP client

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -692,9 +692,9 @@ func (d *Deck) getHTTPClient(ctx context.Context, config *oauth2.Config) (*http.
 
 	retryClient := retryablehttp.NewClient()
 	retryClient.HTTPClient = client
-	retryClient.RetryMax = 5
+	retryClient.RetryMax = 10
 	retryClient.RetryWaitMin = 1 * time.Second
-	retryClient.RetryWaitMax = 10 * time.Second
+	retryClient.RetryWaitMax = 30 * time.Second
 	retryClient.Logger = nil
 
 	return retryClient.StandardClient(), nil


### PR DESCRIPTION
This pull request includes changes to the `getHTTPClient` function in the `deck.go` file to modify the retry behavior of the HTTP client.

Changes to retry behavior:

* Increased the maximum number of retries from 5 to 10.
* Increased the maximum wait time between retries from 10 seconds to 30 seconds.