### PR TITLE
feat: add freeze functionality to skip page modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ The layout name (e.g. `title-and-body`) is specified.
 > title-and-body-3col
 > ```
 
+### `freeze`
+
+It is possible to skip the operation of the target page.
+
+> [!TIP]
+> If you set it to a page that has been completed with layout and design, the page will not be modified unnecessarily by deck.
+
+```markdown
+<!-- {"freeze": true} -->
+```
+
 ## Install
 
 **homebrew tap:**

--- a/deck.go
+++ b/deck.go
@@ -278,8 +278,7 @@ func (d *Deck) SetLogger(logger *slog.Logger) {
 }
 
 func (d *Deck) applyPage(index int, page *md.Page) error {
-	d.logger.Info("appling page", slog.Int("index", 0))
-	defer d.logger.Info("applied page", slog.Int("index", 0))
+	d.logger.Info("appling page", slog.Int("index", index))
 	layoutMap := map[string]*slides.Page{}
 	for _, l := range d.presentation.Layouts {
 		layoutMap[l.LayoutProperties.DisplayName] = l
@@ -294,6 +293,10 @@ func (d *Deck) applyPage(index int, page *md.Page) error {
 		if err := d.CreatePage(index, page); err != nil {
 			return err
 		}
+	}
+	if page.Freeze {
+		d.logger.Info("skip applying page. because freeze:true", slog.Int("index", index))
+		return nil
 	}
 	currentSlide := d.presentation.Slides[index]
 	if currentSlide.SlideProperties.LayoutObjectId != layout.ObjectId {
@@ -535,6 +538,7 @@ func (d *Deck) applyPage(index int, page *md.Page) error {
 		}
 	}
 
+	d.logger.Info("applied page", slog.Int("index", index))
 	return nil
 }
 

--- a/handler/dot/dot.go
+++ b/handler/dot/dot.go
@@ -10,7 +10,10 @@ import (
 	"github.com/mattn/go-colorable"
 )
 
-var yellow = color.New(color.FgYellow, color.Bold).SprintFunc()
+var (
+	yellow = color.New(color.FgYellow, color.Bold).SprintFunc()
+	cyan   = color.New(color.FgCyan).SprintFunc()
+)
 
 func New(h slog.Handler) slog.Handler {
 	return &dotHandler{
@@ -29,10 +32,14 @@ func (h *dotHandler) Enabled(ctx context.Context, level slog.Level) bool {
 }
 
 func (h *dotHandler) Handle(ctx context.Context, r slog.Record) error {
-	if !strings.Contains(r.Message, "applied") {
+	if strings.Contains(r.Message, "applied") {
+		h.stdout.Write([]byte(yellow(".")))
 		return nil
 	}
-	h.stdout.Write([]byte(yellow(".")))
+	if strings.Contains(r.Message, "freeze") {
+		h.stdout.Write([]byte(cyan("*")))
+		return nil
+	}
 	return nil
 }
 

--- a/md/md.go
+++ b/md/md.go
@@ -14,11 +14,13 @@ import (
 type Slides []*Page
 
 type Config struct {
-	Layout string `json:"layout"`
+	Layout string `json:"layout,omitempty"` // layout name
+	Freeze bool   `json:"freeze,omitempty"` // freeze the page
 }
 
 type Page struct {
 	Layout    string   `json:"layout"`
+	Freeze    bool     `json:"freeze,omitempty"`
 	Titles    []string `json:"titles,omitempty"`
 	Subtitles []string `json:"subtitles,omitempty"`
 	Bodies    []*Body  `json:"bodies,omitempty"`
@@ -158,6 +160,7 @@ func ParsePage(b []byte) (*Page, error) {
 					config := &Config{}
 					if err := json.Unmarshal([]byte(block), config); err == nil {
 						page.Layout = config.Layout
+						page.Freeze = config.Freeze
 						return ast.WalkContinue, nil
 					}
 					page.Comments = append(page.Comments, block)

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -13,6 +13,8 @@ func TestParse(t *testing.T) {
 		in string
 	}{
 		{"../testdata/slide.md"},
+		{"../testdata/cap.md"},
+		{"../testdata/freeze.md"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {

--- a/testdata/cap.md.golden
+++ b/testdata/cap.md.golden
@@ -1,0 +1,49 @@
+[
+  {
+    "layout": "",
+    "titles": [
+      "CAP theorem"
+    ],
+    "subtitles": [
+      "In Database theory",
+      "Consistency",
+      "Availability",
+      "Partition tolerance"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Every read receives the most recent write or an error."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Every request received by a non-failing node in the system must result in a response."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "The system continues to operate despite an arbitrary number of messages being dropped (or delayed) by the network between nodes."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/testdata/freeze.md
+++ b/testdata/freeze.md
@@ -1,0 +1,7 @@
+# Freeze
+
+<!-- {"freeze": true} -->
+
+---
+
+# Hello

--- a/testdata/freeze.md.golden
+++ b/testdata/freeze.md.golden
@@ -1,0 +1,21 @@
+[
+  {
+    "layout": "",
+    "freeze": true,
+    "titles": [
+      "Freeze"
+    ],
+    "bodies": [
+      {}
+    ]
+  },
+  {
+    "layout": "",
+    "titles": [
+      "Hello"
+    ],
+    "bodies": [
+      {}
+    ]
+  }
+]


### PR DESCRIPTION
This pull request introduces a new feature to freeze pages in the deck and includes various updates to support this functionality. Additionally, it improves logging and adds new test cases.

### New Feature: Page Freeze
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R137-R147): Added documentation for the new `freeze` feature, which allows skipping the operation of a target page.
* [`md/md.go`](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L17-R23): Updated the `Config` and `Page` structs to include the `Freeze` field, allowing pages to be marked as frozen. [[1]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L17-R23) [[2]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R163)
* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L281-R281): Modified the `applyPage` method to skip applying pages that are marked as frozen and log this action. [[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L281-R281) [[2]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R297-R300) [[3]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R541)

### Logging Improvements
* [`handler/dot/dot.go`](diffhunk://#diff-addbfc1f57ce506eabaa57742bfc6f9230832f210a82c0b47dc4bb0f1605aff6L13-R16): Enhanced the `Handle` method to log a special character for frozen pages and applied pages, improving log readability. [[1]](diffhunk://#diff-addbfc1f57ce506eabaa57742bfc6f9230832f210a82c0b47dc4bb0f1605aff6L13-R16) [[2]](diffhunk://#diff-addbfc1f57ce506eabaa57742bfc6f9230832f210a82c0b47dc4bb0f1605aff6L32-L35)

### Test Updates
* [`md/md_test.go`](diffhunk://#diff-a875d3534d9727c49cb3453f84caac0054354cf1d674fd78fd638afc7593ecf8R16-R17): Added new test cases to cover the `freeze` functionality.
* `testdata/freeze.md`, `testdata/freeze.md.golden`: Added new test data files to validate the freeze feature. [[1]](diffhunk://#diff-8e8fb9b249bc9ed12a56b875eab6ec62deb43eaba522ef3e532eade4e96aa1d9R1-R7) [[2]](diffhunk://#diff-dc6e1d416a1e1060492e0cd2871f3e62990f4f95eedf2281e44ee1dee39fa1feR1-R21)
* [`testdata/cap.md.golden`](diffhunk://#diff-f65671ddf19b0e7ca287286160be1f48f10ccd1f547402be199aab65cbfd910bR1-R49): Added new golden test data for additional coverage.