### PR TITLE
fix(md): remove empty bodies from parsed pages

### DIFF
--- a/md/md.go
+++ b/md/md.go
@@ -184,6 +184,18 @@ func ParsePage(b []byte) (*Page, error) {
 		return nil, err
 	}
 
+	// remove empty bodies
+	notEmpty := false
+	for _, body := range page.Bodies {
+		if len(body.Paragraphs) > 0 {
+			notEmpty = true
+			break
+		}
+	}
+	if !notEmpty {
+		page.Bodies = nil
+	}
+
 	return page, nil
 }
 

--- a/testdata/freeze.md.golden
+++ b/testdata/freeze.md.golden
@@ -4,18 +4,12 @@
     "freeze": true,
     "titles": [
       "Freeze"
-    ],
-    "bodies": [
-      {}
     ]
   },
   {
     "layout": "",
     "titles": [
       "Hello"
-    ],
-    "bodies": [
-      {}
     ]
   }
 ]

--- a/testdata/slide.md.golden
+++ b/testdata/slide.md.golden
@@ -26,9 +26,6 @@
     "titles": [
       "Title"
     ],
-    "bodies": [
-      {}
-    ],
     "comments": [
       "comment",
       "comment"


### PR DESCRIPTION
This pull request includes changes to the `md` package to improve the handling of empty bodies in parsed pages and updates to related test data files. The most important changes include adding logic to remove empty bodies from parsed pages and updating the corresponding test data files to reflect this new behavior.

Improvements to handling empty bodies:

* [`md/md.go`](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R187-R198): Added logic in the `ParsePage` function to check for and remove empty bodies from the `page.Bodies` slice.

Updates to test data files:

* [`testdata/freeze.md.golden`](diffhunk://#diff-dc6e1d416a1e1060492e0cd2871f3e62990f4f95eedf2281e44ee1dee39fa1feL7-L18): Removed empty body objects from the test data to align with the new behavior of the `ParsePage` function.
* [`testdata/slide.md.golden`](diffhunk://#diff-5fd77e2270cf8b48654db0d5f4fb99127edb7378d2c59617089ef3f9f086cad9L29-L31): Updated the test data by removing empty body objects to reflect the changes in the `ParsePage` function.