### PR TITLE
feat(md): add support for converting `<br>` tags to newlines

### DIFF
--- a/md/md_test.go
+++ b/md/md_test.go
@@ -15,6 +15,7 @@ func TestParse(t *testing.T) {
 		{"../testdata/slide.md"},
 		{"../testdata/cap.md"},
 		{"../testdata/freeze.md"},
+		{"../testdata/br.md"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {

--- a/testdata/br.md
+++ b/testdata/br.md
@@ -1,0 +1,3 @@
+# Hello<br>World
+
+Hello<br>World

--- a/testdata/br.md.golden
+++ b/testdata/br.md.golden
@@ -1,0 +1,27 @@
+[
+  {
+    "layout": "",
+    "titles": [
+      "Hello\nWorld"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Hello"
+              },
+              {
+                "value": "\n"
+              },
+              {
+                "value": "World"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This pull request introduces a new `convert` function to handle the conversion of HTML line breaks (`<br>`, `<br/>`, `<br />`) to newline characters (`\n`) in the `md` package. The most important changes include updates to the `ParsePage` and `toFragments` functions to use the new `convert` function, as well as the addition of new test cases and test data to ensure the conversion works correctly.

Updates to `md` package:

* [`md/md.go`](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L108-R114): Updated `ParsePage` and `toFragments` functions to use the new `convert` function for handling HTML line breaks in various parts of the markdown parsing process. [[1]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L108-R114) [[2]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L123-R123) [[3]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L159-R159) [[4]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L171-R171) [[5]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L224-R249)
* [`md/md.go`](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L224-R249): Added the `convert` function and `convertRep` variable to perform the conversion of HTML line breaks to newline characters.

Testing enhancements:

* [`md/md_test.go`](diffhunk://#diff-a875d3534d9727c49cb3453f84caac0054354cf1d674fd78fd638afc7593ecf8R18): Added a new test case `br.md` to the `TestParse` function to verify the correct conversion of HTML line breaks.
* [`testdata/br.md`](diffhunk://#diff-080bc86bd62773e3f1878c2aa2ac97c46beead03d15eacb5fbb2d8543163a257R1-R3): Added new test data file containing markdown with HTML line breaks for testing.
* [`testdata/br.md.golden`](diffhunk://#diff-cbfefe39740ff1a8c1c232f5781c603f7081186d1a359d424e33ce368cb02ff9R1-R27): Added expected output file for the new test data to validate the conversion results.