### PR TITLE
feat(deck): change sig and add start/end option

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -32,7 +32,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var title string
+var (
+	title      string
+	start, end int
+)
 
 var applyCmd = &cobra.Command{
 	Use:   "apply [PRESENTATION_ID] [DECK_FILE]",
@@ -46,18 +49,23 @@ var applyCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		d, err := deck.New(cmd.Context(), id)
-		if err != nil {
-			return err
-		}
 		logger := slog.New(
 			dot.New(slog.NewTextHandler(os.Stdout, nil)),
 		)
-		d.SetLogger(logger)
-
+		opts := []deck.Option{
+			deck.WithPresentationID(id),
+			deck.WithStart(start),
+			deck.WithEnd(end),
+			deck.WithLogger(logger),
+		}
+		d, err := deck.New(cmd.Context(), opts...)
+		if err != nil {
+			return err
+		}
 		if err := d.Apply(slides); err != nil {
 			return err
 		}
+
 		fmt.Println()
 		if title != "" {
 			if err := d.UpdateTitle(title); err != nil {
@@ -71,4 +79,6 @@ var applyCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(applyCmd)
 	applyCmd.Flags().StringVarP(&title, "title", "t", "", "title of the presentation")
+	applyCmd.Flags().IntVarP(&start, "start", "s", 0, "start page of the slide to apply")
+	applyCmd.Flags().IntVarP(&end, "end", "e", 0, "end page of the slide to apply")
 }

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -37,7 +37,7 @@ var exportCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		id := args[0]
-		d, err := deck.New(cmd.Context(), id)
+		d, err := deck.New(cmd.Context(), deck.WithPresentationID(id))
 		if err != nil {
 			return err
 		}

--- a/cmd/lsLayouts.go
+++ b/cmd/lsLayouts.go
@@ -35,7 +35,7 @@ var lsLayoutsCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		id := args[0]
-		d, err := deck.New(cmd.Context(), id)
+		d, err := deck.New(cmd.Context(), deck.WithPresentationID(id))
 		if err != nil {
 			return err
 		}

--- a/deck.go
+++ b/deck.go
@@ -37,7 +37,7 @@ type Deck struct {
 	defaultSectionLayout string
 	defaultLayout        string
 	logger               *slog.Logger
-	start, end           int
+	start, end           int // 1-based
 }
 
 type Option func(*Deck) error
@@ -263,6 +263,12 @@ func (d *Deck) ListLayouts() []string {
 // Apply the markdown slides to the presentation.
 func (d *Deck) Apply(slides md.Slides) error {
 	for i, page := range slides {
+		if d.start > 0 && i < d.start {
+			continue
+		}
+		if d.end > 0 && i >= d.end {
+			break
+		}
 		if page.Layout == "" {
 			switch {
 			case i == 0:

--- a/deck.go
+++ b/deck.go
@@ -37,6 +37,37 @@ type Deck struct {
 	defaultSectionLayout string
 	defaultLayout        string
 	logger               *slog.Logger
+	start, end           int
+}
+
+type Option func(*Deck) error
+
+func WithPresentationID(id string) Option {
+	return func(d *Deck) error {
+		d.id = id
+		return nil
+	}
+}
+
+func WithLogger(logger *slog.Logger) Option {
+	return func(d *Deck) error {
+		d.logger = logger
+		return nil
+	}
+}
+
+func WithStart(start int) Option {
+	return func(d *Deck) error {
+		d.start = start
+		return nil
+	}
+}
+
+func WithEnd(end int) Option {
+	return func(d *Deck) error {
+		d.end = end
+		return nil
+	}
 }
 
 type placeholder struct {
@@ -57,12 +88,16 @@ type Slide struct {
 }
 
 // New creates a new Deck.
-func New(ctx context.Context, id string) (*Deck, error) {
+func New(ctx context.Context, opts ...Option) (*Deck, error) {
 	d, err := initialize(ctx)
 	if err != nil {
 		return nil, err
 	}
-	d.id = id
+	for _, opt := range opts {
+		if err := opt(d); err != nil {
+			return nil, err
+		}
+	}
 	if err := d.refresh(); err != nil {
 		return nil, err
 	}
@@ -271,10 +306,6 @@ func (d *Deck) Export(w io.Writer) error {
 		log.Fatalf("Unable to write PDF file: %v", err)
 	}
 	return nil
-}
-
-func (d *Deck) SetLogger(logger *slog.Logger) {
-	d.logger = logger
 }
 
 func (d *Deck) applyPage(index int, page *md.Page) error {


### PR DESCRIPTION
This pull request introduces several enhancements to the `apply` command in the `cmd/apply.go` file and refactors the `deck` package to support new options for specifying the start and end pages of slides to apply. The key changes include adding new command-line flags, refactoring the `Deck` struct to use functional options, and updating related commands to use these new options.

### Enhancements to `apply` command:

* Added `start` and `end` flags to specify the range of slides to apply. (`cmd/apply.go`) [[1]](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fL35-R38) [[2]](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fR82-R83)
* Refactored the `applyCmd` to use the new `deck.Option` functional options, including `WithPresentationID`, `WithStart`, `WithEnd`, and `WithLogger`. (`cmd/apply.go`)

### Refactoring `deck` package:

* Introduced `Option` type and corresponding functional options (`WithPresentationID`, `WithLogger`, `WithStart`, `WithEnd`) to configure `Deck` instances. (`deck.go`)
* Updated `Deck` struct to include `start` and `end` fields and modified the `New` function to accept variadic options. (`deck.go`)
* Modified `Apply` method in `Deck` to respect `start` and `end` options when applying slides. (`deck.go`)

### Updates to related commands:

* Updated `export` and `lsLayouts` commands to use the new `deck.Option` functional options for creating `Deck` instances. (`cmd/export.go`, `cmd/lsLayouts.go`) [[1]](diffhunk://#diff-e54045fc1fa87e6c263ecf6b52cfb11d8cb7da5dcf3fd5ebceb681a3f98acf5cL40-R40) [[2]](diffhunk://#diff-ecc362e21462471aaa6ff78d223a9d6f0aeb58203bc35beb5b56c18086352bbeL38-R38)