### PR TITLE
fix(md): trim whitespace and newline characters from HTML Block fragment values

### DIFF
--- a/md/md.go
+++ b/md/md.go
@@ -168,7 +168,7 @@ func ParsePage(b []byte) (*Page, error) {
 					currentBody.Paragraphs = append(currentBody.Paragraphs, &Paragraph{
 						Fragments: []*Fragment{
 							{
-								Value:         convert(v.Lines().Value(b)),
+								Value:         convert(bytes.Trim(v.Lines().Value(b), " \n")),
 								Bold:          false,
 								SoftLineBreak: false,
 							},

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -16,6 +16,7 @@ func TestParse(t *testing.T) {
 		{"../testdata/cap.md"},
 		{"../testdata/freeze.md"},
 		{"../testdata/br.md"},
+		{"../testdata/list_and_paragraph.md"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {

--- a/testdata/list_and_paragraph.md
+++ b/testdata/list_and_paragraph.md
@@ -1,0 +1,10 @@
+# Title
+
+- A
+- B
+
+<br><br>
+
+**C**
+D
+E<br>*F*

--- a/testdata/list_and_paragraph.md.golden
+++ b/testdata/list_and_paragraph.md.golden
@@ -1,0 +1,66 @@
+[
+  {
+    "layout": "",
+    "titles": [
+      "Title"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "A"
+              }
+            ],
+            "bullet": "-"
+          },
+          {
+            "fragments": [
+              {
+                "value": "B"
+              }
+            ],
+            "bullet": "-"
+          },
+          {
+            "fragments": [
+              {
+                "value": "\n"
+              },
+              {
+                "value": "\n"
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "C",
+                "bold": true
+              },
+              {
+                "value": "",
+                "softLineBreak": true
+              },
+              {
+                "value": "D",
+                "softLineBreak": true
+              },
+              {
+                "value": "E"
+              },
+              {
+                "value": "\n"
+              },
+              {
+                "value": "F",
+                "italic": true
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This pull request includes changes to improve the parsing and testing of markdown files. The most important changes include trimming whitespace and newline characters from fragment values, adding a new test case, and updating test data files accordingly.

Improvements to parsing:

* [`md/md.go`](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L171-R171): Modified the `ParsePage` function to trim whitespace and newline characters from fragment values.

Enhancements to testing:

* [`md/md_test.go`](diffhunk://#diff-a875d3534d9727c49cb3453f84caac0054354cf1d674fd78fd638afc7593ecf8R19): Added a new test case for parsing a markdown file with lists and paragraphs.
* [`testdata/list_and_paragraph.md`](diffhunk://#diff-467c9549ae265c11ba279bf3f1a55276abebe3bec062ff5d3b5fd5fd9c05e864R1-R10): Added a new markdown test file with lists and paragraphs to be used in the test case.
* [`testdata/list_and_paragraph.md.golden`](diffhunk://#diff-4f6ce6a509cc0dde0ed9f9e83d1564759d492fe622b3848c91e9642cf434a805R1-R66): Added the expected output for the new markdown test file to verify the parsing results.