### PR TITLE
feat: support applying both bold and italic

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -482,11 +482,12 @@ func (d *Deck) applyPage(index int, page *md.Page) error {
 			for _, fragment := range paragraph.Fragments {
 				flen := utf8.RuneCountInString(fragment.Value)
 				if fragment.Bold || fragment.Italic {
-					var fields string
+					var fields []string
 					if fragment.Bold {
-						fields = "bold"
-					} else if fragment.Italic {
-						fields = "italic"
+						fields = append(fields, "bold")
+					}
+					if fragment.Italic {
+						fields = append(fields, "italic")
 					}
 					styleReqs = append(styleReqs, &slides.Request{
 						UpdateTextStyle: &slides.UpdateTextStyleRequest{
@@ -500,7 +501,7 @@ func (d *Deck) applyPage(index int, page *md.Page) error {
 								StartIndex: ptrInt64(int64(count + plen)),
 								EndIndex:   ptrInt64(int64(count + plen + flen)),
 							},
-							Fields: fields,
+							Fields: strings.Join(fields, ","),
 						},
 					})
 				}

--- a/md/md.go
+++ b/md/md.go
@@ -208,12 +208,14 @@ func toFragments(b []byte, n ast.Node) ([]*Fragment, error) {
 			if err != nil {
 				return nil, err
 			}
-			frags = append(frags, &Fragment{
-				Value:         children[0].Value,
-				Bold:          (n.Level == 2),
-				Italic:        (n.Level == 1),
-				SoftLineBreak: children[0].SoftLineBreak,
-			})
+			for _, child := range children {
+				frags = append(frags, &Fragment{
+					Value:         child.Value,
+					Bold:          (n.Level == 2) || child.Bold,
+					Italic:        (n.Level == 1) || child.Italic,
+					SoftLineBreak: child.SoftLineBreak,
+				})
+			}
 		case *ast.Link:
 			children, err := toFragments(b, n)
 			if err != nil {

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -18,6 +18,7 @@ func TestParse(t *testing.T) {
 		{"../testdata/br.md"},
 		{"../testdata/list_and_paragraph.md"},
 		{"../testdata/paragraph_and_list.md"},
+		{"../testdata/bold_and_italic.md"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {

--- a/testdata/bold_and_italic.md
+++ b/testdata/bold_and_italic.md
@@ -1,0 +1,4 @@
+# Title
+
+- _**Bold Italic** and Italic_
+- __*Bold Italic* and Bold__

--- a/testdata/bold_and_italic.md.golden
+++ b/testdata/bold_and_italic.md.golden
@@ -1,0 +1,42 @@
+[
+  {
+    "layout": "",
+    "titles": [
+      "Title"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Bold Italic",
+                "bold": true,
+                "italic": true
+              },
+              {
+                "value": " and Italic",
+                "italic": true
+              }
+            ],
+            "bullet": "-"
+          },
+          {
+            "fragments": [
+              {
+                "value": "Bold Italic",
+                "bold": true,
+                "italic": true
+              },
+              {
+                "value": " and Bold",
+                "bold": true
+              }
+            ],
+            "bullet": "-"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This pull request includes changes to improve the handling of text fragments with bold and italic styles in the `Deck` and `md` packages. Additionally, new test cases and test data have been added to ensure the correct functionality.

Improvements to text fragment handling:

* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L485-R490): Modified the `applyPage` function to use a slice for `fields` and join the slice elements into a string, ensuring both bold and italic styles can be applied simultaneously. [[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L485-R490) [[2]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L503-R504)
* [`md/md.go`](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R211-R218): Updated the `toFragments` function to iterate over all child nodes and correctly apply bold and italic styles to each fragment.

Testing enhancements:

* [`md/md_test.go`](diffhunk://#diff-a875d3534d9727c49cb3453f84caac0054354cf1d674fd78fd638afc7593ecf8R21): Added a new test case to `TestParse` to cover the scenario of fragments with both bold and italic styles.
* [`testdata/bold_and_italic.md`](diffhunk://#diff-5f68060776ff7027f2beb83f35735394d97fe1146c25137f2cf0138871795051R1-R4): Created a new test data file containing text with various combinations of bold and italic styles.
* [`testdata/bold_and_italic.md.golden`](diffhunk://#diff-e518b287c7dc628f9507d06a38b826cc192cfe0e132000f207d89217e87bc399R1-R42): Added a corresponding golden file to validate the expected output for the new test case.