### PR TITLE
fix(deck): clear placeholder for speaker notes in applyPage function

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -398,6 +398,9 @@ func (d *Deck) applyPage(index int, page *md.Page) error {
 		if element.Shape != nil && element.Shape.Placeholder != nil {
 			if element.Shape.Placeholder.Type == "BODY" {
 				speakerNotesID = element.ObjectId
+				if err := d.clearPlaceholder(speakerNotesID); err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This pull request includes a change to the `applyPage` function in the `deck.go` file. The change ensures that the placeholder for speaker notes is cleared before proceeding, which helps to avoid potential errors.

* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R401-R403): Added a call to `d.clearPlaceholder(speakerNotesID)` within the `applyPage` function to clear the placeholder for speaker notes if it exists.