### PR TITLE
fix: apply default layout only when creating a new one

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -249,16 +249,6 @@ func (d *Deck) ListLayouts() []string {
 // Apply the markdown slides to the presentation.
 func (d *Deck) Apply(slides md.Slides) error {
 	for i, page := range slides {
-		if page.Layout == "" {
-			switch {
-			case i == 0:
-				page.Layout = d.defaultTitleLayout
-			case len(page.Bodies) == 0:
-				page.Layout = d.defaultSectionLayout
-			default:
-				page.Layout = d.defaultLayout
-			}
-		}
 		if err := d.applyPage(i, page); err != nil {
 			return err
 		}
@@ -335,6 +325,17 @@ func (d *Deck) applyPage(index int, page *md.Page) error {
 	}
 
 	if len(d.presentation.Slides) <= index {
+		// create new page
+		if page.Layout == "" {
+			switch {
+			case index == 0:
+				page.Layout = d.defaultTitleLayout
+			case len(page.Bodies) == 0:
+				page.Layout = d.defaultSectionLayout
+			default:
+				page.Layout = d.defaultLayout
+			}
+		}
 		if err := d.CreatePage(index, page); err != nil {
 			return err
 		}


### PR DESCRIPTION
This pull request includes changes to the `deck.go` file to improve the handling of page layouts when applying markdown slides to a presentation. The most important changes include moving the logic for setting the default layout from the `Apply` method to the `applyPage` method.

Codebase simplification:

* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L252-L261): Removed the logic for setting the default layout from the `Apply` method and moved it to the `applyPage` method to ensure the layout is set correctly when creating new pages. [[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L252-L261) [[2]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R328-R338)