### PR TITLE
refactor: Introduce a new `deck.Slide` type

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -47,7 +47,7 @@ var applyCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		id := args[0]
 		f := args[1]
-		slides, err := md.ParseFile(f)
+		contents, err := md.ParseFile(f)
 		if err != nil {
 			return err
 		}
@@ -62,11 +62,11 @@ var applyCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		pages, err := pageToPages(page, len(slides))
+		pages, err := pageToPages(page, len(contents))
 		if err != nil {
 			return err
 		}
-		if err := d.ApplyPages(slides, pages); err != nil {
+		if err := d.ApplyPages(contents, pages); err != nil {
 			return err
 		}
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -66,7 +66,7 @@ var applyCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := d.ApplyPages(contents, pages); err != nil {
+		if err := d.ApplyPages(contents.ToSlides(), pages); err != nil {
 			return err
 		}
 

--- a/deck.go
+++ b/deck.go
@@ -18,13 +18,55 @@ import (
 	"unicode/utf8"
 
 	"github.com/hashicorp/go-retryablehttp"
-	"github.com/k1LoW/deck/md"
 	"github.com/pkg/browser"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 	"google.golang.org/api/slides/v1"
+)
+
+type Slides []*Slide
+
+type Slide struct {
+	Layout      string   `json:"layout"`
+	Freeze      bool     `json:"freeze,omitempty"`
+	Titles      []string `json:"titles,omitempty"`
+	Subtitles   []string `json:"subtitles,omitempty"`
+	Bodies      []*Body  `json:"bodies,omitempty"`
+	SpeakerNote string   `json:"speakerNote,omitempty"`
+}
+
+// Body represents the content body of a slide.
+type Body struct {
+	Paragraphs []*Paragraph `json:"paragraphs,omitempty"`
+}
+
+// Paragraph represents a paragraph within a slide body.
+type Paragraph struct {
+	Fragments []*Fragment `json:"fragments,omitempty"`
+	Bullet    Bullet      `json:"bullet,omitempty"`
+	Nesting   int         `json:"nesting,omitempty"`
+}
+
+// Fragment represents a text fragment within a paragraph.
+type Fragment struct {
+	Value         string `json:"value"`
+	Bold          bool   `json:"bold,omitempty"`
+	Italic        bool   `json:"italic,omitempty"`
+	Link          string `json:"link,omitempty"`
+	SoftLineBreak bool   `json:"softLineBreak,omitempty"`
+}
+
+// Bullet represents the type of bullet point for a paragraph.
+type Bullet string
+
+// Bullet constants for different bullet point types.
+const (
+	BulletNone   Bullet = ""
+	BulletDash   Bullet = "-"
+	BulletNumber Bullet = "1"
+	BulletAlpha  Bullet = "a"
 )
 
 type Deck struct {
@@ -63,12 +105,13 @@ type placeholder struct {
 }
 
 type bulletRange struct {
-	bullet md.Bullet
+	bullet Bullet
 	start  int
 	end    int
 }
 
-type Slide struct {
+// Presentation represents a Google Slides presentation.
+type Presentation struct {
 	ID    string
 	Title string
 }
@@ -136,7 +179,7 @@ func CreateFrom(ctx context.Context, id string) (*Deck, error) {
 		return nil, err
 	}
 	// create first slide
-	if err := d.CreatePage(0, &md.Content{
+	if err := d.CreatePage(0, &Slide{
 		Layout: d.defaultTitleLayout,
 	}); err != nil {
 		return nil, err
@@ -145,12 +188,12 @@ func CreateFrom(ctx context.Context, id string) (*Deck, error) {
 }
 
 // List Google Slides presentations.
-func List(ctx context.Context) ([]*Slide, error) {
+func List(ctx context.Context) ([]*Presentation, error) {
 	d, err := initialize(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	var slides []*Slide
+	var presentations []*Presentation
 
 	r, err := d.driveSrv.Files.List().Q("mimeType='application/vnd.google-apps.presentation'").Fields("files(id, name)").Do()
 	if err != nil {
@@ -158,13 +201,13 @@ func List(ctx context.Context) ([]*Slide, error) {
 	}
 
 	for _, f := range r.Files {
-		slides = append(slides, &Slide{
+		presentations = append(presentations, &Presentation{
 			ID:    f.Id,
 			Title: f.Name,
 		})
 	}
 
-	return slides, nil
+	return presentations, nil
 }
 
 func initialize(ctx context.Context) (*Deck, error) {
@@ -219,8 +262,8 @@ func (d *Deck) ID() string {
 }
 
 // List Google Slides presentations.
-func (d *Deck) List() ([]*Slide, error) {
-	var slides []*Slide
+func (d *Deck) List() ([]*Presentation, error) {
+	var presentations []*Presentation
 
 	r, err := d.driveSrv.Files.List().Q("mimeType='application/vnd.google-apps.presentation'").Fields("files(id, name)").Do()
 	if err != nil {
@@ -228,13 +271,13 @@ func (d *Deck) List() ([]*Slide, error) {
 	}
 
 	for _, f := range r.Files {
-		slides = append(slides, &Slide{
+		presentations = append(presentations, &Presentation{
 			ID:    f.Id,
 			Title: f.Name,
 		})
 	}
 
-	return slides, nil
+	return presentations, nil
 }
 
 // ListLayouts lists layouts of the presentation.
@@ -247,9 +290,9 @@ func (d *Deck) ListLayouts() []string {
 }
 
 // Apply the markdown slides to the presentation.
-func (d *Deck) Apply(slides md.Contents) error {
-	for i, content := range slides {
-		if err := d.applyPage(i, content); err != nil {
+func (d *Deck) Apply(slides Slides) error {
+	for i, slide := range slides {
+		if err := d.applyPage(i, slide); err != nil {
 			return err
 		}
 	}
@@ -262,7 +305,7 @@ func (d *Deck) Apply(slides md.Contents) error {
 }
 
 // ApplyPages applies the markdown slides to the presentation with the specified pages.
-func (d *Deck) ApplyPages(slides md.Contents, pages []int) error {
+func (d *Deck) ApplyPages(slides Slides, pages []int) error {
 	for i, content := range slides {
 		if !slices.Contains(pages, i+1) {
 			continue
@@ -312,42 +355,42 @@ func (d *Deck) Export(w io.Writer) error {
 	return nil
 }
 
-func (d *Deck) applyPage(index int, content *md.Content) error {
+func (d *Deck) applyPage(index int, slide *Slide) error {
 	d.logger.Info("appling page", slog.Int("index", index))
 	layoutMap := map[string]*slides.Page{}
 	for _, l := range d.presentation.Layouts {
 		layoutMap[l.LayoutProperties.DisplayName] = l
 	}
 
-	layout, ok := layoutMap[content.Layout]
+	layout, ok := layoutMap[slide.Layout]
 	if !ok {
-		return fmt.Errorf("layout not found: %s", content.Layout)
+		return fmt.Errorf("layout not found: %s", slide.Layout)
 	}
 
 	if len(d.presentation.Slides) <= index {
 		// create new page
-		if content.Layout == "" {
+		if slide.Layout == "" {
 			switch {
 			case index == 0:
-				content.Layout = d.defaultTitleLayout
-			case len(content.Bodies) == 0:
-				content.Layout = d.defaultSectionLayout
+				slide.Layout = d.defaultTitleLayout
+			case len(slide.Bodies) == 0:
+				slide.Layout = d.defaultSectionLayout
 			default:
-				content.Layout = d.defaultLayout
+				slide.Layout = d.defaultLayout
 			}
 		}
-		if err := d.CreatePage(index, content); err != nil {
+		if err := d.CreatePage(index, slide); err != nil {
 			return err
 		}
 	}
-	if content.Freeze {
+	if slide.Freeze {
 		d.logger.Info("skip applying page. because freeze:true", slog.Int("index", index))
 		return nil
 	}
 	currentSlide := d.presentation.Slides[index]
 	if currentSlide.SlideProperties.LayoutObjectId != layout.ObjectId {
 		// create new page
-		if err := d.CreatePage(index+1, content); err != nil {
+		if err := d.CreatePage(index+1, slide); err != nil {
 			return err
 		}
 		if err := d.DeletePage(index); err != nil {
@@ -417,7 +460,7 @@ func (d *Deck) applyPage(index int, content *md.Content) error {
 		}
 		return titles[i].y < titles[j].y
 	})
-	for i, title := range content.Titles {
+	for i, title := range slide.Titles {
 		if len(titles) <= i {
 			continue
 		}
@@ -436,7 +479,7 @@ func (d *Deck) applyPage(index int, content *md.Content) error {
 		}
 		return subtitles[i].y < subtitles[j].y
 	})
-	for i, subtitle := range content.Subtitles {
+	for i, subtitle := range slide.Subtitles {
 		if len(subtitles) <= i {
 			continue
 		}
@@ -452,7 +495,7 @@ func (d *Deck) applyPage(index int, content *md.Content) error {
 	req.Requests = append(req.Requests, &slides.Request{
 		InsertText: &slides.InsertTextRequest{
 			ObjectId: speakerNotesID,
-			Text:     strings.Join(content.Comments, "\n\n"),
+			Text:     slide.SpeakerNote,
 		},
 	})
 
@@ -465,7 +508,7 @@ func (d *Deck) applyPage(index int, content *md.Content) error {
 	})
 	var bulletStartIndex, bulletEndIndex int
 	bulletRanges := map[int]*bulletRange{}
-	for i, body := range content.Bodies {
+	for i, body := range slide.Bodies {
 		if len(bodies) <= i {
 			continue
 		}
@@ -474,10 +517,10 @@ func (d *Deck) applyPage(index int, content *md.Content) error {
 		bulletStartIndex = 0 // reset per body
 		bulletEndIndex = 0   // reset per body
 		var styleReqs []*slides.Request
-		currentBullet := md.BulletNone
+		currentBullet := BulletNone
 		for j, paragraph := range body.Paragraphs {
 			plen := 0
-			if paragraph.Bullet != md.BulletNone {
+			if paragraph.Bullet != BulletNone {
 				if paragraph.Nesting > 0 {
 					text += "\t"
 					plen++
@@ -537,13 +580,13 @@ func (d *Deck) applyPage(index int, content *md.Content) error {
 
 			if len(body.Paragraphs) > j+1 {
 				nextParagraph := body.Paragraphs[j+1]
-				if paragraph.Bullet != nextParagraph.Bullet || paragraph.Bullet != md.BulletNone {
+				if paragraph.Bullet != nextParagraph.Bullet || paragraph.Bullet != BulletNone {
 					text += "\n"
 					plen++
 				}
 			}
 
-			if paragraph.Bullet != md.BulletNone {
+			if paragraph.Bullet != BulletNone {
 				if paragraph.Nesting == 0 && currentBullet != paragraph.Bullet {
 					bulletStartIndex = count
 					bulletEndIndex = count
@@ -600,15 +643,15 @@ func (d *Deck) applyPage(index int, content *md.Content) error {
 	return nil
 }
 
-func (d *Deck) CreatePage(index int, content *md.Content) error {
+func (d *Deck) CreatePage(index int, slide *Slide) error {
 	layoutMap := map[string]*slides.Page{}
 	for _, l := range d.presentation.Layouts {
 		layoutMap[l.LayoutProperties.DisplayName] = l
 	}
 
-	layout, ok := layoutMap[content.Layout]
+	layout, ok := layoutMap[slide.Layout]
 	if !ok {
-		return fmt.Errorf("layout not found: %s", content.Layout)
+		return fmt.Errorf("layout not found: %s", slide.Layout)
 	}
 
 	// create new page
@@ -897,13 +940,13 @@ func ptrInt64(i int64) *int64 {
 	return &i
 }
 
-func convertBullet(b md.Bullet) string {
+func convertBullet(b Bullet) string {
 	switch b {
-	case md.BulletDash:
+	case BulletDash:
 		return "BULLET_DISC_CIRCLE_SQUARE"
-	case md.BulletNumber:
+	case BulletNumber:
 		return "NUMBERED_DIGIT_ALPHA_ROMAN"
-	case md.BulletAlpha:
+	case BulletAlpha:
 		return "NUMBERED_DIGIT_ALPHA_ROMAN"
 	default:
 		return "UNRECOGNIZED"

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -26,11 +26,11 @@ func TestParse(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			slides, err := Parse(b)
+			contents, err := Parse(b)
 			if err != nil {
 				t.Fatal(err)
 			}
-			got, err := json.MarshalIndent(slides, "", "  ")
+			got, err := json.MarshalIndent(contents, "", "  ")
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This pull request refactors the handling of slide data within the codebase by introducing a new `Slide` type in `deck.go` and replacing the older `Page` type from `md.go`. It also updates the processing of markdown files to use `Contents` instead of `Slides`. The changes aim to improve clarity and separation of concerns between the markdown parsing logic and the slide representation.

### Refactoring Slide Representation:
* Introduced a new `Slide` type in `deck.go` to represent slide data, including properties like `Layout`, `Freeze`, `Titles`, `Subtitles`, `Bodies`, and `SpeakerNote`. This replaces the older `Page` type. (`deck.go`, [deck.goR29-R71](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R29-R71))
* Updated methods in `deck.go` to use the new `Slide` type instead of `md.Page`, ensuring consistent handling of slide data. (`deck.go`, [[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L139-R182) [[2]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L265-R323) [[3]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L603-R654)

### Decoupling Markdown Parsing:
* Replaced the `Slides` type in `md.go` with `Contents`, reflecting the separation of markdown parsing from slide representation. (`md.go`, [md/md.goR10-R110](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R10-R110))
* Refactored markdown parsing functions (`ParseFile`, `Parse`) to return `Contents` and updated the parsing logic to work with the new `Content` type. (`md.go`, [[1]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L160-R129) [[2]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L170-R163)

### Codebase Simplification:
* Removed the `md.Bullet` type and related constants, replacing them with the new `Bullet` type in `deck.go`. Updated all references accordingly. (`deck.go`, [[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L900-R949); `md.go`, [[2]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L170-R163)
* Simplified imports by removing `md` from `deck.go` and adding `deck` to `md.go` for shared types. (`deck.go`, [[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L21); `md.go`, [[2]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R10-R110)

### Functional Adjustments:
* Updated the `applyPage` and `CreatePage` methods in `deck.go` to handle the new `Slide` structure, ensuring proper application of layouts and content. (`deck.go`, [[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L315-R393) [[2]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L603-R654)
* Adjusted the `ParseContent` function to correctly map markdown elements to the new `Content` structure, including headings, paragraphs, and bullet points. (`md.go`, [md/md.goL160-R129](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L160-R129))

These changes improve the modularity and maintainability of the code by clearly separating markdown parsing from slide representation and processing.