### PR TITLE
feat: add verbose flag and improve log message handling

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -39,10 +39,11 @@ import (
 )
 
 var (
-	title  string
-	page   string
-	watch  bool
-	logger *slog.Logger
+	title   string
+	page    string
+	watch   bool
+	verbose bool
+	logger  *slog.Logger
 )
 
 var applyCmd = &cobra.Command{
@@ -62,7 +63,7 @@ var applyCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if watch {
+		if verbose {
 			logger = slog.New(
 				slog.NewTextHandler(os.Stdout, nil),
 			)
@@ -114,6 +115,7 @@ func init() {
 	applyCmd.Flags().StringVarP(&title, "title", "t", "", "title of the presentation")
 	applyCmd.Flags().StringVarP(&page, "page", "p", "", "page to apply")
 	applyCmd.Flags().BoolVarP(&watch, "watch", "w", false, "watch for changes")
+	applyCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 }
 
 func pageToPages(page string, total int) ([]int, error) {

--- a/handler/dot/dot.go
+++ b/handler/dot/dot.go
@@ -34,15 +34,15 @@ func (h *dotHandler) Enabled(ctx context.Context, level slog.Level) bool {
 }
 
 func (h *dotHandler) Handle(ctx context.Context, r slog.Record) error {
-	if strings.Contains(r.Message, "applied") {
+	if r.Message == "applied page" {
 		_, _ = h.stdout.Write([]byte(yellow(".")))
 		return nil
 	}
-	if strings.Contains(r.Message, "freeze") {
+	if strings.Contains(r.Message, "because freeze:true") {
 		_, _ = h.stdout.Write([]byte(cyan("*")))
 		return nil
 	}
-	if strings.Contains(r.Message, "apply completed") {
+	if r.Message == "apply completed" {
 		_, _ = h.stdout.Write([]byte("\n"))
 		return nil
 	}


### PR DESCRIPTION
This pull request introduces a new `verbose` flag to the `apply` command and refines the logging behavior in the `dotHandler`. The most important changes include adding the `verbose` flag to the command-line interface, updating the conditional logic for logging, and improving the specificity of log message handling in the `dotHandler`.

### Command-line interface updates:
* Added a new `verbose` flag (`-v`) to the `apply` command for enabling verbose output. This includes defining the flag in the `var` block, initializing it in the `init` function, and updating the condition to enable verbose logging when the flag is set. (`cmd/apply.go`: [[1]](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fR45) [[2]](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fL65-R66) [[3]](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fR118)

### Logging behavior updates:
* Refined the `dotHandler` logic to handle log messages more specifically:
  - Replaced substring checks with exact message matches for "applied page" and "apply completed."
  - Updated the condition for freeze-related messages to check for "because freeze:true" instead of a generic "freeze" substring. (`handler/dot/dot.go`: [handler/dot/dot.goL37-R45](diffhunk://#diff-addbfc1f57ce506eabaa57742bfc6f9230832f210a82c0b47dc4bb0f1605aff6L37-R45))