### PR TITLE
fix: use context.Context

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -57,6 +57,7 @@ var applyCmd = &cobra.Command{
 		return cobra.ExactArgs(2)(cmd, args)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
 		id := args[0]
 		f := args[1]
 		contents, err := md.ParseFile(f)
@@ -76,17 +77,17 @@ var applyCmd = &cobra.Command{
 			deck.WithPresentationID(id),
 			deck.WithLogger(logger),
 		}
-		d, err := deck.New(cmd.Context(), opts...)
+		d, err := deck.New(ctx, opts...)
 		if err != nil {
 			return err
 		}
 		if title != "" {
-			if err := d.UpdateTitle(title); err != nil {
+			if err := d.UpdateTitle(ctx, title); err != nil {
 				return err
 			}
 		}
 		if watch {
-			if err := d.Apply(contents.ToSlides()); err != nil {
+			if err := d.Apply(ctx, contents.ToSlides()); err != nil {
 				return err
 			}
 			logger.Info("initial apply completed", slog.String("presentation_id", id))
@@ -97,7 +98,7 @@ var applyCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			if err := d.ApplyPages(contents.ToSlides(), pages); err != nil {
+			if err := d.ApplyPages(ctx, contents.ToSlides(), pages); err != nil {
 				return err
 			}
 			logger.Info("apply completed", slog.String("presentation_id", id))
@@ -262,7 +263,7 @@ func watchFile(ctx context.Context, filePath string, oldContents md.Contents, d 
 
 			logger.Info("detected changes", slog.Any("pages", changedPages))
 
-			if err := d.ApplyPages(newContents.ToSlides(), changedPages); err != nil {
+			if err := d.ApplyPages(ctx, newContents.ToSlides(), changedPages); err != nil {
 				logger.Error("failed to apply changes", slog.String("error", err.Error()))
 				continue
 			}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -36,8 +36,9 @@ var exportCmd = &cobra.Command{
 	Long:  `export deck.`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
 		id := args[0]
-		d, err := deck.New(cmd.Context(), deck.WithPresentationID(id))
+		d, err := deck.New(ctx, deck.WithPresentationID(id))
 		if err != nil {
 			return err
 		}
@@ -46,7 +47,7 @@ var exportCmd = &cobra.Command{
 			return err
 		}
 		defer f.Close()
-		if err := d.Export(f); err != nil {
+		if err := d.Export(ctx, f); err != nil {
 			return err
 		}
 		return nil

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -35,23 +35,24 @@ var newCmd = &cobra.Command{
 	Short: "create new presentation",
 	Long:  `create new presentation.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
 		var (
 			d   *deck.Deck
 			err error
 		)
 		if from != "" {
-			d, err = deck.CreateFrom(cmd.Context(), from)
+			d, err = deck.CreateFrom(ctx, from)
 			if err != nil {
 				return err
 			}
 		} else {
-			d, err = deck.Create(cmd.Context())
+			d, err = deck.Create(ctx)
 			if err != nil {
 				return err
 			}
 		}
 		if title != "" {
-			if err := d.UpdateTitle(title); err != nil {
+			if err := d.UpdateTitle(ctx, title); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
This pull request introduces a significant refactor to ensure that all methods in the `Deck` package and related commands consistently use a `context.Context` parameter. This change improves context propagation, enabling better cancellation, deadlines, and tracing capabilities across the application. Below is a summary of the most important changes grouped by theme.

### Context Propagation in Command Handlers
* Updated `cmd/apply.go`, `cmd/export.go`, and `cmd/new.go` to initialize `ctx` from `cmd.Context()` and pass it to all `Deck` methods. This ensures consistent context usage throughout command execution. [[1]](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fR60) [[2]](diffhunk://#diff-e54045fc1fa87e6c263ecf6b52cfb11d8cb7da5dcf3fd5ebceb681a3f98acf5cR39-R41) [[3]](diffhunk://#diff-6a7fc12e5c3200a4e07b2084721f45f9ff5b9c271ff42cdac522704329738c95R38-R55)

### Refactoring `Deck` Methods to Accept Context
* Modified all methods in `deck.go` (e.g., `Apply`, `ApplyPages`, `UpdateTitle`, `Export`, `CreatePage`, `DeletePage`, etc.) to include a `context.Context` parameter. This change allows these methods to respect context for operations like API calls and batch updates. [[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L292-R307) [[2]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L322-R347) [[3]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L670-R681)

### API Calls with Context
* Updated all Google Slides API calls to use the `.Context(ctx)` method, ensuring that API requests respect the provided context for cancellation and deadlines. [[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L636-R636) [[2]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L695-R704) [[3]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L719-R729)

### Internal Method Adjustments for Context
* Refactored internal helper methods like `refresh`, `applyPage`, and `clearPlaceholder` to accept and use `context.Context`, ensuring consistent propagation of context within the `Deck` implementation. [[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L357-R357) [[2]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L757-R757)

### Improved Context Handling in Batch Updates
* Ensured that all batch update operations in `deck.go` (e.g., `BatchUpdate` calls for creating, deleting, and applying pages) now explicitly use the context parameter for better control over these operations. [[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L381-R381) [[2]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L719-R729)

These changes enhance the maintainability and robustness of the codebase by standardizing context usage, which is critical for modern applications that rely on external APIs.