### PR TITLE
feat(md): add support for inline code fragments ( parse only )

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -53,6 +53,7 @@ type Fragment struct {
 	Bold          bool   `json:"bold,omitempty"`
 	Italic        bool   `json:"italic,omitempty"`
 	Link          string `json:"link,omitempty"`
+	Code          bool   `json:"code,omitempty"`
 	SoftLineBreak bool   `json:"softLineBreak,omitempty"`
 }
 

--- a/md/md.go
+++ b/md/md.go
@@ -231,6 +231,7 @@ func toFragments(b []byte, n ast.Node) ([]*deck.Fragment, error) {
 				Value:         children[0].Value,
 				Link:          convert(n.Destination),
 				Bold:          children[0].Bold,
+				Italic:        children[0].Italic,
 				SoftLineBreak: children[0].SoftLineBreak,
 			})
 		case *ast.Text:
@@ -266,6 +267,18 @@ func toFragments(b []byte, n ast.Node) ([]*deck.Fragment, error) {
 						SoftLineBreak: false,
 					})
 				}
+			case *ast.CodeSpan:
+				children, err := toFragments(b, typedNode)
+				if err != nil {
+					return nil, err
+				}
+				frags = append(frags, &deck.Fragment{
+					Value:         children[0].Value,
+					Bold:          children[0].Bold,
+					Italic:        children[0].Italic,
+					Code:          true,
+					SoftLineBreak: children[0].SoftLineBreak,
+				})
 			default:
 				// For all other node types, return a newline to match original behavior
 				frags = append(frags, &deck.Fragment{

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -20,6 +20,7 @@ func TestParse(t *testing.T) {
 		{"../testdata/paragraph_and_list.md"},
 		{"../testdata/bold_and_italic.md"},
 		{"../testdata/emoji.md"},
+		{"../testdata/code.md"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {

--- a/testdata/code.md
+++ b/testdata/code.md
@@ -1,0 +1,13 @@
+# Inline Code
+
+---
+
+# Title `with code`
+
+## Hello `code`
+
+- Hello `code`
+- `code` world
+
+`code`
+

--- a/testdata/code.md.golden
+++ b/testdata/code.md.golden
@@ -1,0 +1,55 @@
+[
+  {
+    "layout": "",
+    "titles": [
+      "Inline Code"
+    ]
+  },
+  {
+    "layout": "",
+    "titles": [
+      "Title `with code`"
+    ],
+    "subtitles": [
+      "Hello `code`"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Hello "
+              },
+              {
+                "value": "code",
+                "code": true
+              }
+            ],
+            "bullet": "-"
+          },
+          {
+            "fragments": [
+              {
+                "value": "code",
+                "code": true
+              },
+              {
+                "value": " world"
+              }
+            ],
+            "bullet": "-"
+          },
+          {
+            "fragments": [
+              {
+                "value": "code",
+                "code": true
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Fix: https://github.com/k1LoW/deck/issues/87

Make it possible to parse inline code. However, no decoration.