### PR TITLE
test: add fuzzing test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ deck
 *.json
 *~lock~*
 .DS_Store
+md/testdata/fuzz

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ build:
 lint:
 	golangci-lint run ./...
 
+fuzz:
+	go test -fuzz=FuzzParse -fuzztime=5m ./md/.
+
 depsdev:
 	go install github.com/Songmu/ghch/cmd/ghch@latest
 	go install github.com/Songmu/gocredits/cmd/gocredits@latest

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -47,3 +47,42 @@ func TestParse(t *testing.T) {
 		})
 	}
 }
+
+func FuzzParse(f *testing.F) {
+	f.Add([]byte(`# Title
+
+- A
+- B
+
+<br><br>
+
+**C**
+D
+E<br>*F*
+
+---
+
+# Title
+
+## Subtitle
+
+- aA
+- b**B**
+- cC
+    - dD
+- *e*E
+    - fF
+        - gG
+1. h**H**
+  2. **i**I
+
+ref: [deck repo](https://github.com/k1LoW/deck)
+
+---
+
+# Title
+`))
+	f.Fuzz(func(t *testing.T, in []byte) {
+		_, _ = Parse(in)
+	})
+}


### PR DESCRIPTION
This pull request introduces a new fuzz testing capability for the `Parse` function and updates the `Makefile` to include a new `fuzz` target. These changes aim to improve the robustness of the `Parse` function by testing it with a wide range of inputs.

### Additions to testing:

* [`md/md_test.go`](diffhunk://#diff-a875d3534d9727c49cb3453f84caac0054354cf1d674fd78fd638afc7593ecf8R50-R88): Added a new fuzz test function `FuzzParse` that generates random inputs to test the `Parse` function. This ensures the function can handle unexpected or malformed inputs gracefully.

### Build system updates:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R23-R25): Added a new `fuzz` target under the build commands, which runs the fuzz test for the `Parse` function for a duration of 5 minutes. This integrates fuzz testing into the build process.