### PR TITLE
feat(md): add support for class attributes in fragments

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -63,6 +63,7 @@ type Fragment struct {
 	Link          string `json:"link,omitempty"`
 	Code          bool   `json:"code,omitempty"`
 	SoftLineBreak bool   `json:"softLineBreak,omitempty"`
+	ClassName     string `json:"className,omitempty"`
 }
 
 // Bullet represents the type of bullet point for a paragraph.

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -21,6 +21,7 @@ func TestParse(t *testing.T) {
 		{"../testdata/bold_and_italic.md"},
 		{"../testdata/emoji.md"},
 		{"../testdata/code.md"},
+		{"../testdata/class.md"},
 		{"../testdata/empty_list.md"},
 		{"../testdata/empty_link.md"},
 	}

--- a/testdata/class.md
+++ b/testdata/class.md
@@ -1,0 +1,12 @@
+# Inline Style
+
+---
+
+# Title
+
+## Hello style
+
+- Hello <span class="green" >green</span>
+- <span  class='blue'>blue</span> world
+
+<span class=" red">red</span> world

--- a/testdata/class.md.golden
+++ b/testdata/class.md.golden
@@ -1,0 +1,58 @@
+[
+  {
+    "layout": "",
+    "titles": [
+      "Inline Style"
+    ]
+  },
+  {
+    "layout": "",
+    "titles": [
+      "Title"
+    ],
+    "subtitles": [
+      "Hello style"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Hello "
+              },
+              {
+                "value": "green",
+                "className": "green"
+              }
+            ],
+            "bullet": "-"
+          },
+          {
+            "fragments": [
+              {
+                "value": "blue",
+                "className": "blue"
+              },
+              {
+                "value": " world"
+              }
+            ],
+            "bullet": "-"
+          },
+          {
+            "fragments": [
+              {
+                "value": "red",
+                "className": "red"
+              },
+              {
+                "value": " world"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This pull request introduces support for handling CSS class attributes in HTML-like syntax within markdown files. The main changes include extending the `Fragment` struct, updating the `toFragments` function to process class attributes, and adding new test cases to validate this functionality.

### Enhancements to Markdown Parsing:

* Added a `ClassName` field to the `Fragment` struct in `deck.go` to store CSS class names extracted from HTML-like elements.
* Updated the `toFragments` function in `md/md.go` to extract and assign class attributes from HTML tags using a newly introduced regular expression (`classRe`). This includes handling scenarios like `<span class="green">` or `<span class='blue'>`. [[1]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R214-R232) [[2]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L238-R294) [[3]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R315) [[4]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L297-R331)
* Added the `regexp` package to `md/md.go` for parsing class attributes.

### Testing and Validation:

* Added a new test case (`class.md`) and its corresponding golden file (`class.md.golden`) to verify the correct extraction of CSS class attributes and their inclusion in the parsed output. [[1]](diffhunk://#diff-a875d3534d9727c49cb3453f84caac0054354cf1d674fd78fd638afc7593ecf8R24) [[2]](diffhunk://#diff-f8d3abea7075609b91b8b2eb3d5babf873140fc846dd7a343af6f950f2fdf3f9R1-R12) [[3]](diffhunk://#diff-1735aa773d27e78220573d9d397138ad8b554668ff446a6178f328fec70d02dcR1-R58)