### PR TITLE
fix(md): handle allowed inline HTML elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The system continues to operate despite an arbitrary number of messages being dr
 - Code ( <code>\`code\`</code> )
 - `<br>` (for newline)
 
-#### Style for inline syntax
+#### Style for syntax
 
 Create a layout named `style` and add a `Text box` to enter specific word. The styles (`bold`, `italic`, `underline`, `backgroundColor`, `foregroundColor`, `fontFamily`) will be applied as the style for each Markdown syntax.
 
@@ -134,7 +134,7 @@ Create a layout named `style` and add a `Text box` to enter specific word. The s
 | `italic` | style for *italic*. |
 | `link` | style for [link](#). |
 | `code` | style for `code`. |
-| (other word) | style for content of elements with matching class name ( e.g. `<span class="notice">THIS IS NOTICE</span>` ) |
+| (other word) | style for content of inline HTML elements with matching class name ( e.g. `<span class="notice">THIS IS NOTICE</span>` ) |
 
 ### Comment
 

--- a/testdata/style.md
+++ b/testdata/style.md
@@ -12,4 +12,4 @@
 - Hello <span class="notice" >notice</span>
 - <span  class='unknown'>unknown</span> world
 
-<span class=" unknown'">unknown'</span> world
+<span class=" unknown">unknown</span> world

--- a/testdata/style.md.golden
+++ b/testdata/style.md.golden
@@ -88,8 +88,8 @@
           {
             "fragments": [
               {
-                "value": "unknown'",
-                "className": "unknown'"
+                "value": "unknown",
+                "className": "unknown"
               },
               {
                 "value": " world"


### PR DESCRIPTION
This pull request introduces changes to improve the handling of inline HTML elements in Markdown processing, updates documentation for better clarity, and fixes test cases to align with the new behavior. The most important changes include defining a list of allowed inline HTML elements, refining how closing tags and disallowed elements are handled, and updating test cases accordingly.

### Markdown processing improvements:

* [`md/md.go`](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R18-R23): Added a list of `allowedInlineHTMLElements` to restrict processing to specific inline HTML elements. Updated logic in `toFragments` to skip disallowed elements and reset the class attribute for closing tags. [[1]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R18-R23) [[2]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R271-R276) [[3]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L274-R296)

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L125-R125): Clarified the description of inline HTML element styles and updated section headings for better readability. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L125-R125) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L137-R137)

### Test case fixes:

* `testdata/style.md` and `testdata/style.md.golden`: Fixed test cases to reflect the new behavior of handling inline HTML elements, ensuring accurate results. [[1]](diffhunk://#diff-33f7a178b8637b390f5534da4559443caad69233078c6d6b33469422bed3d1d8L15-R15) [[2]](diffhunk://#diff-f6a68ab325b985f899164fc1b927a8c5ff8237d86bf7acfb99306abcf17f3770L91-R92)