### PR TITLE
fix: improve file change detection for vim compatibility

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -227,7 +227,8 @@ func watchFile(ctx context.Context, filePath string, oldContents md.Contents, d 
 				continue
 			}
 
-			if event.Op&fsnotify.Write != fsnotify.Write {
+			if event.Op&fsnotify.Write != fsnotify.Write && 
+				event.Op&fsnotify.Create != fsnotify.Create {
 				continue
 			}
 


### PR DESCRIPTION
Watch functionality now detects both Write and Create events to support editors like vim that use backup/writebackup options, which create new files instead of modifying existing ones directly.

🤖 Generated with [Claude Code](https://claude.ai/code)