### PR TITLE
fix: resolve duplicate output in markdown lists separated by blank lines

### DIFF
--- a/md/md.go
+++ b/md/md.go
@@ -142,6 +142,10 @@ func ParseContent(b []byte) (*Content, error) {
 					Nesting:   nesting,
 				})
 			case *ast.Paragraph:
+				// Skip paragraphs that are direct children of list items to avoid duplication
+				if v.Parent() != nil && v.Parent().Kind() == ast.KindListItem {
+					return ast.WalkSkipChildren, nil
+				}
 				frags, err := toFragments(b, v)
 				if err != nil {
 					return ast.WalkStop, err

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -24,6 +24,7 @@ func TestParse(t *testing.T) {
 		{"../testdata/style.md"},
 		{"../testdata/empty_list.md"},
 		{"../testdata/empty_link.md"},
+		{"../testdata/lists_with_blankline.md"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {

--- a/testdata/lists_with_blankline.md
+++ b/testdata/lists_with_blankline.md
@@ -1,0 +1,9 @@
+# Lists with blank line
+
+---
+
+# Title
+
+- First list item
+
+- Second list item

--- a/testdata/lists_with_blankline.md.golden
+++ b/testdata/lists_with_blankline.md.golden
@@ -1,0 +1,36 @@
+[
+  {
+    "layout": "",
+    "titles": [
+      "Lists with blank line"
+    ]
+  },
+  {
+    "layout": "",
+    "titles": [
+      "Title"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "First list item"
+              }
+            ],
+            "bullet": "-"
+          },
+          {
+            "fragments": [
+              {
+                "value": "Second list item"
+              }
+            ],
+            "bullet": "-"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Fixed issue where list items separated by blank lines were duplicated in the output. The problem occurred because both ListItem and its child Paragraph nodes were being processed separately by the AST walker.

Changes:
- Skip processing paragraphs that are direct children of list items
- Add test case for lists with blank lines
- Preserve nested list functionality

## sample markdown

```
# Lists with blank line

---

# Title

- First list item

- Second list item
```

## before fix

![CleanShot 2025-06-15 at 13 20 10](https://github.com/user-attachments/assets/33200742-c413-4300-8064-52962a456d64)


## after fix

![CleanShot 2025-06-15 at 13 22 48](https://github.com/user-attachments/assets/84c3c77b-8a07-46ce-a730-ee9f0ff5692f)
