### PR TITLE
feat(md): add support for code blocks in slide content

### DIFF
--- a/md/md.go
+++ b/md/md.go
@@ -31,15 +31,21 @@ type Config struct {
 	Freeze bool   `json:"freeze,omitempty"` // freeze the page
 }
 
+type CodeBlock struct {
+	Language string `json:"language,omitempty"`
+	Value    string `json:"value"`
+}
+
 // Content represents a single slide content.
 type Content struct {
-	Layout    string        `json:"layout"`
-	Freeze    bool          `json:"freeze,omitempty"`
-	Titles    []string      `json:"titles,omitempty"`
-	Subtitles []string      `json:"subtitles,omitempty"`
-	Bodies    []*deck.Body  `json:"bodies,omitempty"`
-	Images    []*deck.Image `json:"images,omitempty"` // images in the content
-	Comments  []string      `json:"comments,omitempty"`
+	Layout     string        `json:"layout"`
+	Freeze     bool          `json:"freeze,omitempty"`
+	Titles     []string      `json:"titles,omitempty"`
+	Subtitles  []string      `json:"subtitles,omitempty"`
+	Bodies     []*deck.Body  `json:"bodies,omitempty"`
+	Images     []*deck.Image `json:"images,omitempty"`
+	CodeBlocks []*CodeBlock  `json:"code_blocks,omitempty"`
+	Comments   []string      `json:"comments,omitempty"`
 }
 
 // toBullet converts a marker byte to a Bullet type.
@@ -190,6 +196,18 @@ func ParseContent(baseDir string, b []byte) (*Content, error) {
 						Nesting: 0,
 					})
 				}
+			case *ast.CodeBlock:
+				value := v.Lines().Value(b)
+				content.CodeBlocks = append(content.CodeBlocks, &CodeBlock{
+					Value: string(value),
+				})
+			case *ast.FencedCodeBlock:
+				lang := v.Language(b)
+				value := v.Lines().Value(b)
+				content.CodeBlocks = append(content.CodeBlocks, &CodeBlock{
+					Language: string(lang),
+					Value:    string(value),
+				})
 			}
 		}
 		return ast.WalkContinue, nil

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -26,6 +26,7 @@ func TestParse(t *testing.T) {
 		{"../testdata/empty_link.md"},
 		{"../testdata/lists_with_blankline.md"},
 		{"../testdata/images.md"},
+		{"../testdata/codeblock.md"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {

--- a/testdata/codeblock.md
+++ b/testdata/codeblock.md
@@ -1,0 +1,24 @@
+# Code Block
+
+---
+
+# Blocks
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, 世界")
+}
+```
+
+```ts
+const anExampleVariable = "Hello World"
+console.log(anExampleVariable)
+```
+
+```
+Hello World
+```

--- a/testdata/codeblock.md.golden
+++ b/testdata/codeblock.md.golden
@@ -1,0 +1,27 @@
+[
+  {
+    "layout": "",
+    "titles": [
+      "Code Block"
+    ]
+  },
+  {
+    "layout": "",
+    "titles": [
+      "Blocks"
+    ],
+    "code_blocks": [
+      {
+        "language": "go",
+        "value": "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"Hello, 世界\")\n}\n"
+      },
+      {
+        "language": "ts",
+        "value": "const anExampleVariable = \"Hello World\"\nconsole.log(anExampleVariable)\n"
+      },
+      {
+        "value": "Hello World\n"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This pull request introduces support for parsing and handling code blocks in markdown content within the `md` package. The changes include adding a new `CodeBlock` type, updating the parsing logic to extract code blocks, and extending the test suite to validate the new functionality.

### Feature Addition: Code Block Support

* **`md/md.go`:** Added a new `CodeBlock` struct to represent code blocks with optional language and value fields. Updated the `Content` struct to include a `CodeBlocks` field for storing parsed code blocks. Enhanced the `ParseContent` function to identify and handle both regular and fenced code blocks, extracting their language and content. [[1]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R34-R47) [[2]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R199-R210)

### Testing Enhancements

* **`md/md_test.go`:** Added a new test case to validate the parsing of code blocks using the `codeblock.md` test data.
* **`testdata/codeblock.md`:** Introduced a markdown file containing examples of regular and fenced code blocks in various languages for testing purposes.
* **`testdata/codeblock.md.golden`:** Created a corresponding golden file to define the expected output structure, including parsed code blocks with language and value fields.