### PR TITLE
fix(md): introduce Parser struct for markdown parsing

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -60,7 +60,11 @@ var applyCmd = &cobra.Command{
 		ctx := cmd.Context()
 		id := args[0]
 		f := args[1]
-		contents, err := md.ParseFile(f)
+		p, err := md.New()
+		if err != nil {
+			return err
+		}
+		contents, err := p.ParseFile(f)
 		if err != nil {
 			return err
 		}
@@ -227,7 +231,7 @@ func watchFile(ctx context.Context, filePath string, oldContents md.Contents, d 
 				continue
 			}
 
-			if event.Op&fsnotify.Write != fsnotify.Write && 
+			if event.Op&fsnotify.Write != fsnotify.Write &&
 				event.Op&fsnotify.Create != fsnotify.Create {
 				continue
 			}
@@ -238,7 +242,12 @@ func watchFile(ctx context.Context, filePath string, oldContents md.Contents, d 
 			var parseErr error
 
 			for retry := range 3 {
-				newContents, parseErr = md.ParseFile(filePath)
+				p, err := md.New()
+				if err != nil {
+					parseErr = err
+				} else {
+					newContents, parseErr = p.ParseFile(filePath)
+				}
 				if parseErr == nil {
 					break
 				}

--- a/integration_test.go
+++ b/integration_test.go
@@ -43,7 +43,11 @@ func TestApplyMarkdown(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			contents, err := md.Parse("testdata", b)
+			p, err := md.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			contents, err := p.Parse("testdata", b)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -103,7 +107,11 @@ func TestMarkdownToSlide(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			contents, err := md.Parse("testdata", b)
+			p, err := md.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			contents, err := p.Parse("testdata", b)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -34,7 +34,11 @@ func TestParse(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			contents, err := Parse("../testdata", b)
+			p, err := New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			contents, err := p.Parse("../testdata", b)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -88,6 +92,9 @@ ref: [deck repo](https://github.com/k1LoW/deck)
 # Title
 `))
 	f.Fuzz(func(t *testing.T, in []byte) {
-		_, _ = Parse(".", in)
+		p, _ := New()
+		if p != nil {
+			_, _ = p.Parse(".", in)
+		}
 	})
 }


### PR DESCRIPTION
This pull request refactors the markdown parsing logic by introducing a new `Parser` struct in the `md` package. The changes centralize parsing functionality within the `Parser` struct, enabling greater flexibility and extensibility for parsing markdown files and content. The most important changes include the creation of the `Parser` struct, updates to parsing methods to use the `Parser` instance, and modifications to tests to accommodate the new structure.

### Refactoring markdown parsing:

* **Introduced `Parser` struct**: Added a new `Parser` struct and a corresponding constructor function `New` with optional configuration via `ParserOption`. This allows for future extensibility and customization of the parsing behavior. (`md/md.go`, [md/md.goR51-R67](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R51-R67))
* **Refactored parsing methods**: Updated all parsing methods (`ParseFile`, `Parse`, and `ParseContent`) to be instance methods of the `Parser` struct instead of standalone functions. This change ensures that parsing operations are encapsulated within the `Parser` instance. (`md/md.go`, [[1]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L62-R86) [[2]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L83-R98)

### Updates to `cmd/apply.go`:

* **Applied `Parser` changes**: Modified the `applyCmd` and `watchFile` functions to create a `Parser` instance using `md.New()` and use it for file parsing. This aligns the command logic with the new `Parser` structure. (`cmd/apply.go`, [[1]](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fL63-R67) [[2]](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fL241-R250)

### Updates to tests:

* **Refactored tests to use `Parser`**: Updated all test cases in `integration_test.go` and `md_test.go` to create a `Parser` instance and use it for parsing operations. This ensures that tests are compatible with the new parsing structure. (`integration_test.go`, [[1]](diffhunk://#diff-ed1088fda4ca38792b99302b355705eb525017fca294e83858422bb430d8cc59L46-R50) [[2]](diffhunk://#diff-ed1088fda4ca38792b99302b355705eb525017fca294e83858422bb430d8cc59L106-R114); `md/md_test.go`, [[3]](diffhunk://#diff-a875d3534d9727c49cb3453f84caac0054354cf1d674fd78fd638afc7593ecf8L37-R41) [[4]](diffhunk://#diff-a875d3534d9727c49cb3453f84caac0054354cf1d674fd78fd638afc7593ecf8L91-R98)