### PR TITLE
fix(deck): simplify default*Layout logic

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -38,17 +38,16 @@ const (
 )
 
 type Deck struct {
-	id                   string
-	dataHomePath         string
-	stateHomePath        string
-	srv                  *slides.Service
-	driveSrv             *drive.Service
-	presentation         *slides.Presentation
-	defaultTitleLayout   string
-	defaultSectionLayout string
-	defaultLayout        string
-	styles               map[string]*slides.TextStyle
-	logger               *slog.Logger
+	id                 string
+	dataHomePath       string
+	stateHomePath      string
+	srv                *slides.Service
+	driveSrv           *drive.Service
+	presentation       *slides.Presentation
+	defaultTitleLayout string
+	defaultLayout      string
+	styles             map[string]*slides.TextStyle
+	logger             *slog.Logger
 }
 
 type Option func(*Deck) error
@@ -294,8 +293,6 @@ func (d *Deck) ApplyPages(ctx context.Context, ss Slides, pages []int) error {
 			switch {
 			case i == 0:
 				slide.Layout = d.defaultTitleLayout
-			case len(slide.Bodies) == 0:
-				slide.Layout = d.defaultSectionLayout
 			default:
 				slide.Layout = d.defaultLayout
 			}
@@ -435,8 +432,6 @@ func (d *Deck) applyPage(ctx context.Context, index int, slide *Slide) error {
 			switch {
 			case index == 0:
 				slide.Layout = d.defaultTitleLayout
-			case len(slide.Bodies) == 0:
-				slide.Layout = d.defaultSectionLayout
 			default:
 				slide.Layout = d.defaultLayout
 			}
@@ -1119,10 +1114,6 @@ func (d *Deck) refresh(ctx context.Context) error {
 			if d.defaultTitleLayout == "" {
 				d.defaultTitleLayout = l.LayoutProperties.DisplayName
 			}
-		case strings.HasPrefix(layout, "SECTION_HEADER"):
-			if d.defaultSectionLayout == "" {
-				d.defaultSectionLayout = l.LayoutProperties.DisplayName
-			}
 		}
 
 		if l.LayoutProperties.DisplayName == layoutNameForStyle {
@@ -1141,6 +1132,16 @@ func (d *Deck) refresh(ctx context.Context) error {
 					d.styles[className] = t.TextRun.Style
 				}
 			}
+		}
+	}
+	if d.defaultTitleLayout == "" {
+		d.defaultTitleLayout = d.presentation.Layouts[0].LayoutProperties.DisplayName
+	}
+	if d.defaultLayout == "" {
+		if len(d.presentation.Layouts) > 1 {
+			d.defaultLayout = d.presentation.Layouts[1].LayoutProperties.DisplayName
+		} else {
+			d.defaultLayout = d.presentation.Layouts[0].LayoutProperties.DisplayName
 		}
 	}
 


### PR DESCRIPTION
This pull request simplifies the layout management logic in the `Deck` struct within the `deck.go` file. The changes remove the `defaultSectionLayout` property and its associated logic, consolidating layout handling into `defaultTitleLayout` and `defaultLayout`.

### Simplification of layout management:

* Removed the `defaultSectionLayout` field from the `Deck` struct, streamlining the layout properties. (`[deck.goL48](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L48)`)
* Removed conditional logic that applied `defaultSectionLayout` to slides with empty bodies in the `ApplyPages` and `applyPage` methods. (`[[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L297-L298)`, `[[2]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L438-L439)`)
* Removed the initialization of `defaultSectionLayout` in the `refresh` method, reducing complexity in layout detection. (`[deck.goL1122-L1125](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L1122-L1125)`)
* Added fallback logic in the `refresh` method to ensure `defaultTitleLayout` and `defaultLayout` are always initialized, using the first and second layouts from `presentation.Layouts` respectively. (`[deck.goR1137-R1146](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R1137-R1146)`)