### PR TITLE
fix(md): rename `value` to `content` in code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,11 +172,11 @@ There are three ways to receive code block information within the command:
 
 2. **Receive as environment variables**
    - `CODEBLOCK_LANG`: Optional language identifier of the code block (e.g., `go`, `python`)
-   - `CODEBLOCK_VALUE`: Content of the code block
+   - `CODEBLOCK_CONTENT`: Content of the code block
 
 3. **Receive with template syntax ( with [expr-lang](https://expr-lang.org/) )**
    - `{{lang}}`: Optional language identifier of the code block
-   - `{{value}}`: Content of the code block
+   - `{{content}}`: Content of the code block
    - `{{env.XXX}}`: Value of environment variable XXX
 
 These methods can be used in combination, and you can choose the appropriate method according to the command requirements.

--- a/testdata/codeblock.md.golden
+++ b/testdata/codeblock.md.golden
@@ -13,18 +13,18 @@
     "code_blocks": [
       {
         "language": "go",
-        "value": "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"Hello, 世界\")\n}\n"
+        "content": "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"Hello, 世界\")\n}\n"
       },
       {
         "language": "ts",
-        "value": "const anExampleVariable = \"Hello World\"\nconsole.log(anExampleVariable)\n"
+        "content": "const anExampleVariable = \"Hello World\"\nconsole.log(anExampleVariable)\n"
       },
       {
         "language": "mermaid",
-        "value": "graph TD\n    A[md.Contents] --\u003e B[deck.Slide];\n    B --\u003e C[Google Slides];\n"
+        "content": "graph TD\n    A[md.Contents] --\u003e B[deck.Slide];\n    B --\u003e C[Google Slides];\n"
       },
       {
-        "value": "Hello World\n"
+        "content": "Hello World\n"
       }
     ]
   }


### PR DESCRIPTION
This pull request introduces a key change to the terminology used for code block data, replacing "Value" with "Content" across the codebase. This improves clarity and aligns variable names with their intended meaning. The changes span documentation, code definitions, parsing logic, and tests.

### Terminology Update: "Value" to "Content"

* **Documentation (`README.md`)**: Updated references to code block data, replacing `CODEBLOCK_VALUE` with `CODEBLOCK_CONTENT` and `{{value}}` with `{{content}}`.

* **Struct Definition (`md/md.go`)**: Renamed the `CodeBlock` struct field from `Value` to `Content` for consistency.

* **Parsing Logic (`md/md.go`)**: Modified parsing functions to use `Content` instead of `Value` when handling code block data.

* **Environment Variables (`md/md.go`)**: Updated environment variable names to use `CODEBLOCK_CONTENT` while keeping `CODEBLOCK_VALUE` as a deprecated alias for backward compatibility. [[1]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L254-R259) [[2]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L267-R272)

* **Test Data (`testdata/codeblock.md.golden`)**: Adjusted test data to reflect the terminology change, ensuring all code block entries now use `content`.