### PR TITLE
fix(deck): rename methods and add logging for page operations

### DIFF
--- a/handler/dot/dot.go
+++ b/handler/dot/dot.go
@@ -13,6 +13,8 @@ import (
 var (
 	yellow = color.New(color.FgYellow, color.Bold).SprintFunc()
 	cyan   = color.New(color.FgCyan).SprintFunc()
+	gray   = color.New(color.FgHiBlack).SprintFunc()
+	green  = color.New(color.FgGreen).SprintFunc()
 )
 
 var _ slog.Handler = (*dotHandler)(nil)
@@ -36,6 +38,22 @@ func (h *dotHandler) Enabled(ctx context.Context, level slog.Level) bool {
 func (h *dotHandler) Handle(ctx context.Context, r slog.Record) error {
 	if r.Message == "applied page" {
 		_, _ = h.stdout.Write([]byte(yellow(".")))
+		return nil
+	}
+	if r.Message == "deleted page" {
+		_, _ = h.stdout.Write([]byte(gray("x")))
+		return nil
+	}
+	if r.Message == "appended page" {
+		_, _ = h.stdout.Write([]byte(yellow("+")))
+		return nil
+	}
+	if r.Message == "moved page" {
+		_, _ = h.stdout.Write([]byte(green("-")))
+		return nil
+	}
+	if r.Message == "inserted page" {
+		_, _ = h.stdout.Write([]byte(yellow("+")))
 		return nil
 	}
 	if strings.Contains(r.Message, "because freeze:true") {

--- a/integration_action_test.go
+++ b/integration_action_test.go
@@ -32,7 +32,7 @@ func TestApplyAction(t *testing.T) {
 				{Layout: "title-and-body", Titles: []string{"Slide 1"}},
 			},
 			actions: func(t *testing.T, d *Deck) {
-				if err := d.appendPage(ctx, &Slide{Layout: "title-and-body", Titles: []string{"Slide 2"}}); err != nil {
+				if err := d.AppendPage(ctx, &Slide{Layout: "title-and-body", Titles: []string{"Slide 2"}}); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -45,7 +45,7 @@ func TestApplyAction(t *testing.T) {
 			name:   "append slide (index 0)",
 			before: Slides{},
 			actions: func(t *testing.T, d *Deck) {
-				if err := d.appendPage(ctx, &Slide{Layout: "title-and-body", Titles: []string{"Slide 1"}}); err != nil {
+				if err := d.AppendPage(ctx, &Slide{Layout: "title-and-body", Titles: []string{"Slide 1"}}); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -59,7 +59,7 @@ func TestApplyAction(t *testing.T) {
 				{Layout: "title-and-body", Titles: []string{"Slide 1"}},
 			},
 			actions: func(t *testing.T, d *Deck) {
-				if err := d.insertPage(ctx, 0, &Slide{Layout: "title-and-body", Titles: []string{"Slide 2"}}); err != nil {
+				if err := d.InsertPage(ctx, 0, &Slide{Layout: "title-and-body", Titles: []string{"Slide 2"}}); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -75,7 +75,7 @@ func TestApplyAction(t *testing.T) {
 				{Layout: "title-and-body", Titles: []string{"Slide 2"}},
 			},
 			actions: func(t *testing.T, d *Deck) {
-				if err := d.insertPage(ctx, 1, &Slide{Layout: "title-and-body", Titles: []string{"Slide 1.5"}}); err != nil {
+				if err := d.InsertPage(ctx, 1, &Slide{Layout: "title-and-body", Titles: []string{"Slide 1.5"}}); err != nil {
 					t.Fatal(err)
 				}
 			},


### PR DESCRIPTION
ref: https://github.com/k1LoW/deck/issues/149

This pull request refactors the `Deck` class in `deck.go` to improve code organization, enhance logging, and update method naming conventions. It also introduces visual feedback for specific log messages in the `dotHandler` and updates related tests in `integration_action_test.go`.

### Refactoring and Method Updates:
* Replaced private methods (`createPage`, `appendPage`, `insertPage`, `movePage`, `deletePage`) with public counterparts (`CreatePage`, `AppendPage`, `InsertPage`, `MovePage`, `DeletePage`) for better clarity and accessibility. [[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L151-R151) [[2]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L344-R358) [[3]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L923-R932) [[4]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L1010-R963) [[5]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R975-R1029) [[6]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R1046-R1089) [[7]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L1419-R1441)

### Logging Enhancements:
* Added detailed logging for actions such as appending, inserting, moving, and deleting pages to improve traceability. [[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L344-R358) [[2]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L923-R932) [[3]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L1010-R963) [[4]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R975-R1029) [[5]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R1046-R1089)

### Handler Updates:
* Enhanced `dotHandler` in `handler/dot/dot.go` to provide visual feedback for specific log messages:
  - `"deleted page"` logs as a gray "x".
  - `"appended page"` and `"inserted page"` log as yellow "+".
  - `"moved page"` logs as green "-". [[1]](diffhunk://#diff-addbfc1f57ce506eabaa57742bfc6f9230832f210a82c0b47dc4bb0f1605aff6R16-R17) [[2]](diffhunk://#diff-addbfc1f57ce506eabaa57742bfc6f9230832f210a82c0b47dc4bb0f1605aff6R43-R58)

### Test Updates:
* Updated tests in `integration_action_test.go` to use the new public methods (`AppendPage`, `InsertPage`) instead of the old private ones (`appendPage`, `insertPage`). [[1]](diffhunk://#diff-f5f31088d88a94141876d202167e04166442a517bd1383310b3db7eb30b05425L35-R35) [[2]](diffhunk://#diff-f5f31088d88a94141876d202167e04166442a517bd1383310b3db7eb30b05425L48-R48) [[3]](diffhunk://#diff-f5f31088d88a94141876d202167e04166442a517bd1383310b3db7eb30b05425L62-R62) [[4]](diffhunk://#diff-f5f31088d88a94141876d202167e04166442a517bd1383310b3db7eb30b05425L78-R78)