### PR TITLE
fix(deck): correct log levels for debug and warn messages

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -1898,10 +1898,16 @@ func (l *apiLogger) Info(msg string, keysAndValues ...any) {
 	l.l.Info(msg, append([]any{slog.String("original_log_level", "info")}, keysAndValues...)...)
 }
 func (l *apiLogger) Debug(msg string, keysAndValues ...any) {
-	l.l.Info(msg, append([]any{slog.String("original_log_level", "debug")}, keysAndValues...)...)
+	if strings.HasPrefix(msg, "retrying") {
+		// If the message starts with "retrying", log it as info instead of debug
+		// For displaying spinner messages in the console
+		l.l.Info(msg, append([]any{slog.String("original_log_level", "debug")}, keysAndValues...)...)
+		return
+	}
+	l.l.Debug(msg, append([]any{slog.String("original_log_level", "debug")}, keysAndValues...)...)
 }
 func (l *apiLogger) Warn(msg string, keysAndValues ...any) {
-	l.l.Info(msg, append([]any{slog.String("original_log_level", "warn")}, keysAndValues...)...)
+	l.l.Warn(msg, append([]any{slog.String("original_log_level", "warn")}, keysAndValues...)...)
 }
 
 func newAPILogger(l *slog.Logger) retryablehttp.LeveledLogger {


### PR DESCRIPTION
This pull request introduces a logging enhancement in the `deck.go` file. The change modifies the behavior of the `Debug` method in the `apiLogger` struct to log certain messages as `Info` instead of `Debug` based on their content.

Logging behavior adjustment:

* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R1901-R1910): Updated the `Debug` method in the `apiLogger` struct to check if the message starts with "retrying". If it does, the message is logged as `Info` instead of `Debug`. This adjustment is intended to display retry-related messages more prominently in the console, aiding visibility during operations.