### PR TITLE
feat(logger): enhance dot handler for deleted/moved pages

### DIFF
--- a/logger/dot/dot.go
+++ b/logger/dot/dot.go
@@ -50,7 +50,7 @@ func (h *dotHandler) Handle(ctx context.Context, r slog.Record) error {
 		return nil
 	}
 	if r.Message == "deleted page" {
-		_, _ = h.stdout.Write([]byte(gray("x")))
+		_, _ = h.stdout.Write([]byte(gray("-")))
 		return nil
 	}
 	if r.Message == "appended page" {
@@ -58,7 +58,22 @@ func (h *dotHandler) Handle(ctx context.Context, r slog.Record) error {
 		return nil
 	}
 	if r.Message == "moved page" {
-		_, _ = h.stdout.Write([]byte(green("-")))
+		var from, to int64
+		r.Attrs(func(attr slog.Attr) bool {
+			if attr.Key == "from_index" {
+				from = attr.Value.Int64()
+			}
+			if attr.Key == "to_index" {
+				to = attr.Value.Int64()
+			}
+			return true
+		})
+		switch {
+		case from < to:
+			_, _ = h.stdout.Write([]byte(green("↓")))
+		case from > to:
+			_, _ = h.stdout.Write([]byte(green("↑")))
+		}
 		return nil
 	}
 	if r.Message == "inserted page" {


### PR DESCRIPTION
This pull request updates the visual representation of log messages in the `dotHandler` to improve clarity and provide more context for certain operations. The changes include replacing symbols for specific log messages and adding logic to handle directional movement for "moved page" events.

Updates to log message handling:

* [`logger/dot/dot.go`](diffhunk://#diff-458ebcb76d1a0720101a735727a244196a8419a8a2de9c9f7e0cfe630a8db880L53-R76): Changed the symbol for "deleted page" from `x` to `-` for consistency with other log messages.
* [`logger/dot/dot.go`](diffhunk://#diff-458ebcb76d1a0720101a735727a244196a8419a8a2de9c9f7e0cfe630a8db880L53-R76): Enhanced the "moved page" message by introducing logic to display directional arrows (`↓` or `↑`) based on the `from_index` and `to_index` attributes, providing clearer context about the movement direction.