### PR TITLE
fix: cache calculated checksums and pHash values for image comparison

### DIFF
--- a/action.go
+++ b/action.go
@@ -872,17 +872,23 @@ func imagesEqual(images1, images2 []*Image) bool {
 	if len(images1) != len(images2) {
 		return false
 	}
-
-	images1B, err := json.Marshal(images1)
-	if err != nil {
-		return false
+	var imageChecksums1 []uint32
+	var imageChecksums2 []uint32
+	for _, img := range images1 {
+		if img == nil {
+			continue // Skip nil images
+		}
+		imageChecksums1 = append(imageChecksums1, img.Checksum())
 	}
-	images2B, err := json.Marshal(images2)
-	if err != nil {
-		return false
+	for _, img := range images2 {
+		if img == nil {
+			continue // Skip nil images
+		}
+		imageChecksums2 = append(imageChecksums2, img.Checksum())
 	}
-
-	return bytes.Equal(images1B, images2B)
+	slices.Sort(imageChecksums1)
+	slices.Sort(imageChecksums2)
+	return slices.Equal(imageChecksums1, imageChecksums2)
 }
 
 // applyDeleteMarks applies delete marks from after slides to corresponding before slides


### PR DESCRIPTION
This pull request refactors image comparison logic to improve efficiency and introduces new methods for handling image checksums and perceptual hashing. The most important changes include replacing JSON-based comparison with checksum-based comparison, adding new fields and methods to the `Image` struct, and updating image comparison logic to use these new methods.

### Refactoring image comparison:

* [`action.go`](diffhunk://#diff-655efec79154066c3d13d880da14f16b32e0a01d8d5703ddfd4177746c5f2c5cL875-R891): Replaced JSON-based comparison in `imagesEqual` with checksum-based comparison, ensuring more efficient and accurate handling of image equality. Added sorting of checksums before comparison to account for order differences.

### Enhancements to the `Image` struct:

* [`slide.go`](diffhunk://#diff-9b512ff450c4d8f204d811a69ae2ed95048d738c05504738d77a91bf3e9ade7cR82-R84): Added new fields (`url`, `checksum`, and `pHash`) to the `Image` struct for storing image metadata, including a checksum for efficient comparison and a perceptual hash for JPEG images.
* [`slide.go`](diffhunk://#diff-9b512ff450c4d8f204d811a69ae2ed95048d738c05504738d77a91bf3e9ade7cR181-R204): Introduced the `Checksum` method to compute and cache the CRC32 checksum of image data, and the `PHash` method to compute and cache perceptual hashes for JPEG images.

### Updates to image creation and comparison logic:

* [`slide.go`](diffhunk://#diff-9b512ff450c4d8f204d811a69ae2ed95048d738c05504738d77a91bf3e9ade7cL112-R121): Modified `NewImage` to set the `url` field when creating an image from a path or URL. Improved error handling when creating images from buffers.
* [`slide.go`](diffhunk://#diff-9b512ff450c4d8f204d811a69ae2ed95048d738c05504738d77a91bf3e9ade7cL147-R166): Updated `CompareImages` to use the new `Checksum` and `PHash` methods, improving efficiency and accuracy for image comparisons, especially for JPEG images.