### PR TITLE
fix(md): correct image copying logic in ToSlides

### DIFF
--- a/md/md.go
+++ b/md/md.go
@@ -242,7 +242,7 @@ func (contents Contents) ToSlides(ctx context.Context, codeBlockToImageCmd strin
 	slides := make([]*deck.Slide, len(contents))
 	for i, content := range contents {
 		var images []*deck.Image
-		_ = copy(images, content.Images)
+		images = append(images, content.Images...)
 		if codeBlockToImageCmd != "" && len(content.CodeBlocks) > 0 {
 			mu := sync.Mutex{}
 			eg := errgroup.Group{}


### PR DESCRIPTION
This pull request improves the handling of image slices in the `ToSlides` method of the `md/md.go` file. The change simplifies the code by replacing the use of `copy` with `append` for combining slices.

Code simplification:

* [`md/md.go`](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L245-R245): Updated the `ToSlides` method to use `append` instead of `copy` for adding elements from `content.Images` to the `images` slice, ensuring proper handling of slice initialization and appending.