### PR TITLE
fix: respond when images are manually deleted in Google Slides

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -282,6 +282,9 @@ func (d *Deck) Apply(ctx context.Context, slides Slides) error {
 
 // ApplyPages applies the markdown slides to the presentation with the specified pages.
 func (d *Deck) ApplyPages(ctx context.Context, ss Slides, pages []int) error {
+	if err := d.refresh(ctx); err != nil {
+		return fmt.Errorf("failed to refresh presentation: %w", err)
+	}
 	layoutObjectIdMap := map[string]*slides.Page{}
 	for _, l := range d.presentation.Layouts {
 		layoutObjectIdMap[l.ObjectId] = l


### PR DESCRIPTION
This pull request introduces a small but important change to the `ApplyPages` method in `deck.go`. The change ensures the presentation is refreshed before applying markdown slides to specified pages, improving reliability and error handling.

* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R285-R287): Added a call to `d.refresh(ctx)` at the beginning of the `ApplyPages` method to refresh the presentation. If the refresh fails, an error is returned with a descriptive message.