### PR TITLE
refactor(deck): remove redundant DeletePageAfter call in ApplyPages function

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -378,12 +378,6 @@ func (d *Deck) ApplyPages(ctx context.Context, ss Slides, pages []int) error {
 		}
 	}
 
-	// Note: DeletePageAfter is still needed to handle cases where slides are reduced
-	// but not explicitly deleted through diff actions (e.g., when the new slide count is less)
-	if err := d.DeletePageAfter(ctx, len(ss)-1); err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This pull request simplifies the `ApplyPages` method in `deck.go` by removing unnecessary code related to handling slide deletions.

Code simplification:

* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L381-L386): Removed the call to `DeletePageAfter` and its associated logic, as it is no longer needed to handle cases where slides are reduced but not explicitly deleted through diff actions.