### PR TITLE
fix: prepend identifiers with type in object ID generation

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -931,7 +931,7 @@ func (d *Deck) applyPage(ctx context.Context, index int, slide *Slide) error {
 			return fmt.Errorf("webContentLink is empty for image: %s", uploaded.Id)
 		}
 
-		imageObjectID := uuid.New().String()
+		imageObjectID := fmt.Sprintf("image-%s", uuid.New().String())
 		req.Requests = append(req.Requests, &slides.Request{
 			CreateImage: &slides.CreateImageRequest{
 				ObjectId: imageObjectID,
@@ -1541,7 +1541,7 @@ func (d *Deck) updateLayout(ctx context.Context, index int, slide *Slide) error 
 			var paragraphInfos []paragraphInfo
 			currentIndex := int64(0)
 			text := ""
-			shapeObjectID := uuid.New().String()
+			shapeObjectID := fmt.Sprintf("shape-%s", uuid.New().String())
 
 			for _, textElement := range element.Shape.Text.TextElements {
 				if textElement.ParagraphMarker != nil {


### PR DESCRIPTION
This pull request includes changes to improve the readability and consistency of object IDs in the `deck.go` file by updating how UUIDs are formatted for image and shape objects.

Enhancements to object ID formatting:

* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L934-R934): Updated the `imageObjectID` in the `applyPage` method to use a formatted string (`image-<UUID>`) for better readability and consistency.
* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L1544-R1544): Updated the `shapeObjectID` in the `updateLayout` method to use a formatted string (`shape-<UUID>`) for better readability and consistency.