### PR TITLE
feat(logger): add red color for failure messages

### DIFF
--- a/logger/dot/dot.go
+++ b/logger/dot/dot.go
@@ -17,6 +17,7 @@ var (
 	cyan   = color.New(color.FgCyan).SprintFunc()
 	gray   = color.New(color.FgHiBlack).SprintFunc()
 	green  = color.New(color.FgGreen).SprintFunc()
+	red    = color.New(color.FgRed).SprintFunc()
 )
 
 var _ slog.Handler = (*dotHandler)(nil)
@@ -107,6 +108,12 @@ func (h *dotHandler) Handle(ctx context.Context, r slog.Record) error {
 	}
 	if strings.Contains(r.Message, "because freeze:true") {
 		if err := h.write([]byte(cyan("*"))); err != nil {
+			return err
+		}
+		return nil
+	}
+	if strings.Contains(r.Message, "failed to") {
+		if err := h.write([]byte(red("!"))); err != nil {
 			return err
 		}
 		return nil


### PR DESCRIPTION
This pull request introduces enhancements to the `dotHandler` in `logger/dot/dot.go` for improved logging functionality. The changes add support for displaying error messages in red when specific failure-related text is detected in log records.

### Logging Enhancements:

* **Added red color formatting for error messages**: Introduced a `red` color formatter using `color.New(color.FgRed).SprintFunc()` to visually distinguish error messages. (`logger/dot/dot.go`, [logger/dot/dot.goR20](diffhunk://#diff-458ebcb76d1a0720101a735727a244196a8419a8a2de9c9f7e0cfe630a8db880R20))
* **Handling failure messages**: Updated the `Handle` method to check if a log record's message contains "failed to". If detected, the handler writes a red exclamation mark (`!`) to the output for emphasis. (`logger/dot/dot.go`, [logger/dot/dot.goR115-R120](diffhunk://#diff-458ebcb76d1a0720101a735727a244196a8419a8a2de9c9f7e0cfe630a8db880R115-R120))