### PR TITLE
feat(apply): switch to JSON logging when `--verbose` and enhance action details structure

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -67,7 +67,7 @@ var applyCmd = &cobra.Command{
 		}
 		if verbose {
 			logger = slog.New(
-				slog.NewTextHandler(os.Stdout, nil),
+				slog.NewJSONHandler(os.Stdout, nil),
 			)
 		} else {
 			h, err := dot.New(slog.NewTextHandler(os.Stdout, nil))

--- a/deck.go
+++ b/deck.go
@@ -82,6 +82,13 @@ type bulletRange struct {
 	end    int64
 }
 
+type actionDetail struct {
+	ActionType  actionType `json:"action_type"`
+	Titles      []string   `json:"titles,omitempty"`
+	Index       *int       `json:"index,omitempty"`
+	MoveToIndex *int       `json:"move_to_index,omitempty"`
+}
+
 // Presentation represents a Google Slides presentation.
 type Presentation struct {
 	ID    string
@@ -336,17 +343,37 @@ func (d *Deck) ApplyPages(ctx context.Context, ss Slides, pages []int) error {
 		return fmt.Errorf("failed to generate actions: %w", err)
 	}
 
-	var actionDetails []string
+	var actionDetails []actionDetail
 	for _, action := range actions {
 		switch action.actionType {
 		case actionTypeAppend:
-			actionDetails = append(actionDetails, fmt.Sprintf("append slide at index %d: %s", len(d.presentation.Slides), action.slide.Titles))
+			actionDetails = append(actionDetails, actionDetail{
+				ActionType:  actionTypeAppend,
+				Titles:      action.slide.Titles,
+				Index:       nil,
+				MoveToIndex: nil,
+			})
 		case actionTypeInsert:
-			actionDetails = append(actionDetails, fmt.Sprintf("insert slide at index %d: %s", action.index, action.slide.Titles))
+			actionDetails = append(actionDetails, actionDetail{
+				ActionType:  actionTypeInsert,
+				Titles:      action.slide.Titles,
+				Index:       &action.index,
+				MoveToIndex: nil,
+			})
 		case actionTypeUpdate:
-			actionDetails = append(actionDetails, fmt.Sprintf("update slide at index %d: %s", action.index, action.slide.Titles))
+			actionDetails = append(actionDetails, actionDetail{
+				ActionType:  actionTypeUpdate,
+				Titles:      action.slide.Titles,
+				Index:       &action.index,
+				MoveToIndex: nil,
+			})
 		case actionTypeMove:
-			actionDetails = append(actionDetails, fmt.Sprintf("move slide from index %d to %d: %s", action.index, action.moveToIndex, action.slide.Titles))
+			actionDetails = append(actionDetails, actionDetail{
+				ActionType:  actionTypeMove,
+				Titles:      action.slide.Titles,
+				Index:       &action.index,
+				MoveToIndex: &action.moveToIndex,
+			})
 		}
 	}
 	d.logger.Info("applying actions", slog.Any("actions", actionDetails))


### PR DESCRIPTION
This pull request introduces changes to improve logging and refactor the handling of slide actions in the codebase. The most important changes include switching the logging format to JSON for better machine readability and introducing a new `actionDetail` type to simplify and structure the representation of slide actions.

### Logging Improvements:
* [`cmd/apply.go`](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fL70-R70): Updated the logging handler from `slog.NewTextHandler` to `slog.NewJSONHandler` to output logs in JSON format for improved readability and integration with logging systems.

### Refactoring Slide Actions:
* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3R85-R91): Added a new `actionDetail` type to encapsulate details about slide actions, including action type, titles, and indices. This replaces the previous approach of using formatted strings.
* [`deck.go`](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L339-R376): Refactored the `ApplyPages` method to use the new `actionDetail` type for handling slide actions, improving code clarity and maintainability.