### PR TITLE
feat: add YAML frontmatter support with new Presentation type

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,27 @@ This is useful during the content creation process as it allows you to see your 
 
 ## Support markdown rules
 
+### YAML Frontmatter
+
+`deck` accepts YAML frontmatter at the beginning of your markdown file for future extensibility. Currently, all field content is parsed but not used.
+
+```markdown
+---
+title: My Presentation
+---
+
+# First Slide
+
+Content...
+```
+
+The frontmatter must be:
+- At the very beginning of the file
+- Enclosed between `---` delimiters
+- Valid YAML syntax
+
+Note: This feature is reserved for future enhancements.
+
 ### Insertion rule
 
 `deck` inserts values according to the following rules regardless of the slide layout.

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -61,10 +61,11 @@ var applyCmd = &cobra.Command{
 		ctx := cmd.Context()
 		id := args[0]
 		f := args[1]
-		contents, err := md.ParseFile(f)
+		presentation, err := md.ParseFile(f)
 		if err != nil {
 			return err
 		}
+		contents := presentation.Contents
 		if verbose {
 			logger = slog.New(
 				slog.NewJSONHandler(os.Stdout, nil),
@@ -250,8 +251,10 @@ func watchFile(ctx context.Context, filePath string, oldContents md.Contents, d 
 			var parseErr error
 
 			for retry := range 3 {
-				newContents, parseErr = md.ParseFile(filePath)
+				var newPresentation *md.Presentation
+				newPresentation, parseErr = md.ParseFile(filePath)
 				if parseErr == nil {
+					newContents = newPresentation.Contents
 					break
 				}
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/corona10/goimagehash v1.1.0
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/goccy/go-yaml v1.17.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
@@ -32,7 +33,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/goccy/go-yaml v1.17.1 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.2 // indirect

--- a/integration_test.go
+++ b/integration_test.go
@@ -44,11 +44,11 @@ func TestApplyMarkdown(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			contents, err := md.Parse("testdata", b)
+			presentation, err := md.Parse("testdata", b)
 			if err != nil {
 				t.Fatal(err)
 			}
-			fromMd, err := contents.ToSlides(ctx, "")
+			fromMd, err := presentation.Contents.ToSlides(ctx, "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -109,11 +109,11 @@ func TestMarkdownToSlide(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			contents, err := md.Parse("testdata", b)
+			presentation, err := md.Parse("testdata", b)
 			if err != nil {
 				t.Fatal(err)
 			}
-			fromMd, err := contents.ToSlides(ctx, "")
+			fromMd, err := presentation.Contents.ToSlides(ctx, "")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/md/frontmatter_test.go
+++ b/md/frontmatter_test.go
@@ -1,0 +1,98 @@
+package md
+
+import (
+	"testing"
+)
+
+func TestFrontmatter(t *testing.T) {
+	tests := []struct {
+		name     string
+		markdown string
+		want     *Frontmatter
+	}{
+		{
+			name: "with frontmatter",
+			markdown: `---
+title: Test Title
+author: Test Author
+tags:
+  - tag1
+  - tag2
+---
+
+# Slide Title
+
+Content`,
+			want: &Frontmatter{},
+		},
+		{
+			name: "without frontmatter",
+			markdown: `# Slide Title
+
+Content`,
+			want: nil,
+		},
+		{
+			name:     "empty frontmatter",
+			markdown: "---\n---\n\n# Slide Title",
+			want:     &Frontmatter{},
+		},
+		{
+			name: "frontmatter with trailing delimiter",
+			markdown: `---
+title: Test
+---
+# Slide Title`,
+			want: &Frontmatter{},
+		},
+		{
+			name: "frontmatter with any fields (all ignored)",
+			markdown: `---
+title: Test Title
+author: Test Author
+unknown_field: ignored
+custom_data: 
+  nested: value
+metadata:
+  key1: value1
+  key2: value2
+tags:
+  - tag1
+  - tag2
+---
+# Slide Title`,
+			want: &Frontmatter{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			presentation, err := Parse(".", []byte(tt.markdown))
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+
+			if presentation == nil {
+				t.Fatal("Parse() returned nil presentation")
+			}
+
+			got := presentation.Frontmatter
+
+			// Check if frontmatter matches expected value
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("Parse() frontmatter = %+v, want nil", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Errorf("Parse() frontmatter = nil, want non-nil empty struct")
+				return
+			}
+
+			// Since Frontmatter is an empty struct, just verify it's not nil when expected
+			// All YAML fields are ignored, so no field comparison needed
+		})
+	}
+}

--- a/md/md.go
+++ b/md/md.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/goccy/go-yaml"
 	"github.com/k1LoW/deck"
 	"github.com/k1LoW/errors"
 	"github.com/k1LoW/exec"
@@ -28,6 +29,16 @@ var allowedInlineHTMLElements = []string{
 	"<mark", "<q", "<rp", "<rt", "<ruby", "<s", "<samp", "<small", "<span",
 	"<strong", "<sub", "<sup", "<time", "<u", "<var",
 }
+
+// Presentation represents a markdown presentation.
+type Presentation struct {
+	Frontmatter *Frontmatter
+	Contents    Contents
+}
+
+// Frontmatter represents YAML frontmatter data.
+// All YAML fields are ignored during unmarshaling for now.
+type Frontmatter struct{}
 
 // Contents represents a collection of slide contents.
 type Contents []*Content
@@ -56,7 +67,7 @@ type Content struct {
 }
 
 // ParseFile parses a markdown file into contents.
-func ParseFile(f string) (_ Contents, err error) {
+func ParseFile(f string) (_ *Presentation, err error) {
 	defer func() {
 		err = errors.WithStack(err)
 	}()
@@ -75,22 +86,39 @@ func ParseFile(f string) (_ Contents, err error) {
 
 // Parse parses markdown bytes into contents.
 // It splits the input by "---" delimiters and parses each section as a separate content.
-func Parse(baseDir string, b []byte) (_ Contents, err error) {
+func Parse(baseDir string, b []byte) (_ *Presentation, err error) {
 	defer func() {
 		err = errors.WithStack(err)
 	}()
 
+	// Extract YAML frontmatter if present
+	var frontmatter *Frontmatter
+	mayHaveFrontmatter := bytes.HasPrefix(b, []byte("---\n"))
 	bpages := bytes.Split(bytes.TrimPrefix(b, []byte("---\n")), []byte("\n---\n"))
+
+	if mayHaveFrontmatter && len(bpages) > 0 {
+		maybeYAMLContent := bpages[0]
+		frontmatter = &Frontmatter{}
+		if err := yaml.Unmarshal(maybeYAMLContent, frontmatter); err == nil {
+			bpages = bpages[1:] // Remove the first page if it contains frontmatter
+		} else {
+			frontmatter = nil
+		}
+	}
+
 	contents := make(Contents, len(bpages))
 	for i, bpage := range bpages {
-		content, err := ParseContent(baseDir, bpage)
+		c, err := ParseContent(baseDir, bpage)
 		if err != nil {
 			return nil, err
 		}
-		contents[i] = content
+		contents[i] = c
 	}
 
-	return contents, nil
+	return &Presentation{
+		Frontmatter: frontmatter,
+		Contents:    contents,
+	}, nil
 }
 
 // ParseContent parses a single markdown content into a Content structure.

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -28,6 +28,7 @@ func TestParse(t *testing.T) {
 		{"../testdata/nested_list.md"},
 		{"../testdata/images.md"},
 		{"../testdata/codeblock.md"},
+		{"../testdata/frontmatter.md"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
@@ -35,11 +36,11 @@ func TestParse(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			contents, err := Parse("../testdata", b)
+			presentation, err := Parse("../testdata", b)
 			if err != nil {
 				t.Fatal(err)
 			}
-			got, err := json.MarshalIndent(contents, "", "  ")
+			got, err := json.MarshalIndent(presentation.Contents, "", "  ")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/testdata/frontmatter.md
+++ b/testdata/frontmatter.md
@@ -1,0 +1,30 @@
+---
+title: YAML Frontmatter Test
+author: Test Author
+date: 2024-01-01
+tags:
+  - test
+  - frontmatter
+  - yaml
+custom:
+  nested: value
+  number: 42
+---
+
+# Title with Frontmatter
+
+## Subtitle
+
+This is a test slide with YAML frontmatter.
+
+<!-- {"layout":"title"} -->
+
+---
+
+# Second Slide
+
+- Item 1
+- Item 2
+- Item 3
+
+The frontmatter should only be available in the first slide.

--- a/testdata/frontmatter.md.golden
+++ b/testdata/frontmatter.md.golden
@@ -1,0 +1,67 @@
+[
+  {
+    "layout": "title",
+    "titles": [
+      "Title with Frontmatter"
+    ],
+    "subtitles": [
+      "Subtitle"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This is a test slide with YAML frontmatter."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "layout": "",
+    "titles": [
+      "Second Slide"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Item 1"
+              }
+            ],
+            "bullet": "-"
+          },
+          {
+            "fragments": [
+              {
+                "value": "Item 2"
+              }
+            ],
+            "bullet": "-"
+          },
+          {
+            "fragments": [
+              {
+                "value": "Item 3"
+              }
+            ],
+            "bullet": "-"
+          },
+          {
+            "fragments": [
+              {
+                "value": "The frontmatter should only be available in the first slide."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
- Add YAML frontmatter parsing at the beginning of markdown files
- Introduce Presentation type to encapsulate frontmatter and contents

My presentation Markdown files often include Frontmatter, so I would appreciate a format that supports it.
I am also considering future extensions, such as adding a slideID.