### PR TITLE
fix: add CODEBLOCK_CONTENT env to cmd

### DIFF
--- a/md/md.go
+++ b/md/md.go
@@ -319,7 +319,8 @@ func (contents Contents) ToSlides(ctx context.Context, codeBlockToImageCmd strin
 					cmd.Stdin = strings.NewReader(codeBlock.Content)
 					cmd.Env = os.Environ()
 					cmd.Env = append(cmd.Env, fmt.Sprintf("CODEBLOCK_LANG=%s", codeBlock.Language))
-					cmd.Env = append(cmd.Env, fmt.Sprintf("CODEBLOCK_VALUE=%s", codeBlock.Content))
+					cmd.Env = append(cmd.Env, fmt.Sprintf("CODEBLOCK_CONTENT=%s", codeBlock.Content))
+					cmd.Env = append(cmd.Env, fmt.Sprintf("CODEBLOCK_VALUE=%s", codeBlock.Content)) // Deprecated, use CODEBLOCK_CONTENT.
 					var (
 						stdout bytes.Buffer
 						stderr bytes.Buffer


### PR DESCRIPTION
I thought it might be better to common the code around the env, but I added it straightforward for now.