### PR TITLE
feat: change heading policy to use first heading as title and consecutive second heading as subtitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Note: This feature is reserved for future enhancements.
 
 `deck` inserts values according to the following rules regardless of the slide layout.
 
-- Heading1 (`#`) is inserted into the title placeholder ( `CENTERED_TITLE` or `TITLE` ) in order.
-- Heading2 (`##`) is inserted into the subtitle placeholder ( `SUBTITLE` ) in order.
+- The first heading (any level) is inserted into the title placeholder ( `CENTERED_TITLE` or `TITLE` ).
+- The second heading (any level) is inserted into the subtitle placeholder ( `SUBTITLE` ) only if it immediately follows the first heading with no other content in between.
 - All other items are inserted into the body placeholder ( `BODY` ) in order.
 
 > [!NOTE]

--- a/testdata/cap.md.golden
+++ b/testdata/cap.md.golden
@@ -5,10 +5,7 @@
       "CAP theorem"
     ],
     "subtitles": [
-      "In Database theory",
-      "Consistency",
-      "Availability",
-      "Partition tolerance"
+      "In Database theory"
     ],
     "bodies": [
       {
@@ -16,25 +13,41 @@
           {
             "fragments": [
               {
+                "value": "Consistency",
+                "bold": true
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
                 "value": "Every read receives the most recent write or an error."
               }
             ]
-          }
-        ]
-      },
-      {
-        "paragraphs": [
+          },
+          {
+            "fragments": [
+              {
+                "value": "Availability",
+                "bold": true
+              }
+            ]
+          },
           {
             "fragments": [
               {
                 "value": "Every request received by a non-failing node in the system must result in a response."
               }
             ]
-          }
-        ]
-      },
-      {
-        "paragraphs": [
+          },
+          {
+            "fragments": [
+              {
+                "value": "Partition tolerance",
+                "bold": true
+              }
+            ]
+          },
           {
             "fragments": [
               {

--- a/testdata/slide.md.golden
+++ b/testdata/slide.md.golden
@@ -151,12 +151,19 @@
       "1"
     ],
     "subtitles": [
-      "2",
-      "3"
+      "2"
     ],
     "bodies": [
       {
         "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "3",
+                "bold": true
+              }
+            ]
+          },
           {
             "fragments": [
               {
@@ -171,13 +178,10 @@
   {
     "layout": "title-and-body-3col",
     "titles": [
-      "1"
+      "2"
     ],
     "subtitles": [
-      "2",
-      "3",
-      "4",
-      "5"
+      "1"
     ],
     "bodies": [
       {
@@ -185,25 +189,41 @@
           {
             "fragments": [
               {
+                "value": "3",
+                "bold": true
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
                 "value": "a"
               }
             ]
-          }
-        ]
-      },
-      {
-        "paragraphs": [
+          },
+          {
+            "fragments": [
+              {
+                "value": "4",
+                "bold": true
+              }
+            ]
+          },
           {
             "fragments": [
               {
                 "value": "b"
               }
             ]
-          }
-        ]
-      },
-      {
-        "paragraphs": [
+          },
+          {
+            "fragments": [
+              {
+                "value": "5",
+                "bold": true
+              }
+            ]
+          },
           {
             "fragments": [
               {


### PR DESCRIPTION
- Change from level-based (H1=title, H2=subtitle) to position-based heading policy
- First heading (any level) becomes title
- The second heading becomes a subtitle only if it immediately follows the first heading
- All other headings are treated as body content with bold formatting

**This is a welcome behavior for me, but it may not be for you. I would like to discuss it.**

## Motivation

- Sometimes I want to use h2 or h3 as slide titles
    - I want to organize the outline of the entire document
    - For example, I want to make section titles h1 and everything after that h2
- About changes to the subtitle policy
    - BREAKING: Only headings immediately after titles should be a subtitle
    - In the current behavior, if the headings in the middle or back of the slide are treated as subtitles, the order of the information may become confused.
    - Google Slides can only have one SUBTITLE per slide (?), which seems natural, so if there are multiple headings on a slide, it might be better to treat the second and subsequent headings as body text.

In the future, I would like to be able to specify the default slide layout based on the heading level of the title.