### PR TITLE
feat: add angle bracket autolinks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The system continues to operate despite an arbitrary number of messages being dr
 - List ( `-` `*` )
 - Ordered list ( `1.` `1)` )
 - Link ( `[Link](https://example.com)` )
+- Angle bracket autolinks ( `<https://example.com>` )
 - Code ( <code>\`code\`</code> )
 - `<br>` (for newline)
 - Image (`![Image](path/to/image.png)` )

--- a/md/md.go
+++ b/md/md.go
@@ -406,6 +406,14 @@ func toFragments(baseDir string, b []byte, n ast.Node) (_ []*deck.Fragment, _ []
 				ClassName:     className,
 			})
 			images = append(images, childImages...)
+		case *ast.AutoLink:
+			url := string(childNode.URL(b))
+			label := string(childNode.Label(b))
+			frags = append(frags, &deck.Fragment{
+				Value:     label,
+				Link:      url,
+				ClassName: className,
+			})
 		case *ast.Text:
 			v := convert(childNode.Segment.Value(b))
 			if v == "" {

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -29,6 +29,7 @@ func TestParse(t *testing.T) {
 		{"../testdata/images.md"},
 		{"../testdata/codeblock.md"},
 		{"../testdata/frontmatter.md"},
+		{"../testdata/autolink.md"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {

--- a/testdata/autolink.md
+++ b/testdata/autolink.md
@@ -1,0 +1,13 @@
+# Autolink Test Cases
+
+This is a normal link: [example](https://example.com)
+
+Bracketed autolinks (should be converted):
+- <https://example.com>
+
+Naked URLs (should NOT be converted):
+- https://example.com
+
+Mixed content:
+- Visit <https://github.com> for more info
+- Or go to https://github.com directly

--- a/testdata/autolink.md.golden
+++ b/testdata/autolink.md.golden
@@ -1,0 +1,86 @@
+[
+  {
+    "layout": "",
+    "titles": [
+      "Autolink Test Cases"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This is a normal link: "
+              },
+              {
+                "value": "example",
+                "link": "https://example.com"
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "Bracketed autolinks (should be converted):"
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "https://example.com",
+                "link": "https://example.com"
+              }
+            ],
+            "bullet": "-"
+          },
+          {
+            "fragments": [
+              {
+                "value": "Naked URLs (should NOT be converted):"
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "https://example.com"
+              }
+            ],
+            "bullet": "-"
+          },
+          {
+            "fragments": [
+              {
+                "value": "Mixed content:"
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "Visit "
+              },
+              {
+                "value": "https://github.com",
+                "link": "https://github.com"
+              },
+              {
+                "value": " for more info"
+              }
+            ],
+            "bullet": "-"
+          },
+          {
+            "fragments": [
+              {
+                "value": "Or go to https://github.com directly"
+              }
+            ],
+            "bullet": "-"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
- Support <https://example.com> autolinks
- Convert to clickable links in Google Slides
- Exclude naked URLs from automatic conversion

It is important to display URLs in presentations to indicate sources.
Here, we support URL linking using angle brackets, which is standard in Markdown.
URLs that are not enclosed in angle brackets will not be automatically converted.