### PR TITLE
feat: support dynamic heading levels for title detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,16 @@ Note: This feature is reserved for future enhancements.
 
 `deck` inserts values according to the following rules regardless of the slide layout.
 
-- Heading1 (`#`) is inserted into the title placeholder ( `CENTERED_TITLE` or `TITLE` ) in order.
-- Heading2 (`##`) is inserted into the subtitle placeholder ( `SUBTITLE` ) in order.
+- The minimum heading level within each slide content is treated as the title and inserted into the title placeholder ( `CENTERED_TITLE` or `TITLE` ) in order.
+  - In most cases, this will be H1 (`#`), which is the standard for slide titles
+- The next heading level (minimum level + 1) is treated as the subtitle and inserted into the subtitle placeholder ( `SUBTITLE` ) in order.
+  - When H1 is used for titles, H2 (`##`) becomes the subtitle
 - All other items are inserted into the body placeholder ( `BODY` ) in order.
+
+For example:
+- **Standard case**: If a slide contains `#` (H1), then `#` becomes title and `##` becomes subtitle
+- **Alternative case**: If a slide only contains `##` (H2) or higher, then `##` becomes title and `###` becomes subtitle
+- This allows flexibility in creating slides from various markdown content structures while maintaining familiar heading hierarchies
 
 > [!NOTE]
 > They are inserted in the order they appear in the markdown document, **from the placeholder at the top of the slide** (or from the placeholder on the left if the slides are the same height).
@@ -302,7 +309,7 @@ For example, it is a good idea to provide the following rules for creating deck 
     Unless otherwise specified, please follow the rules below.
 
     - Use `---` to indicate page breaks in slides.
-    - Only `#` and `##` can be used for headings. Do not use headings with `###` or higher. It is recommended to use only one heading per page.
+    - Within each slide, the minimum heading level will be treated as the title, and the next level as the subtitle. Higher level headings will be treated as body content. It is recommended to use only one title heading per slide.
     - The following syntax can be used in the page body. Note that it cannot be used in headings.
         - Bold ( `**bold**` )
         - Italic ( `*italic*` `__italic__` )

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -30,6 +30,7 @@ func TestParse(t *testing.T) {
 		{"../testdata/codeblock.md"},
 		{"../testdata/frontmatter.md"},
 		{"../testdata/autolink.md"},
+		{"../testdata/heading.md"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {

--- a/testdata/heading.md
+++ b/testdata/heading.md
@@ -1,0 +1,135 @@
+# Normal H1 only slide
+
+This is a slide with only H1 headings.
+
+# Another H1 slide
+
+Content for the second H1 slide.
+
+---
+
+# H1 and H2 slide
+
+This is an H1 title.
+
+## H2 subtitle
+
+Content under H2.
+
+## Another H2 subtitle
+
+More content under H2.
+
+# Next H1 slide
+
+Another main slide.
+
+---
+
+## H2 only slide
+
+This is a slide with only H2 headings.
+
+## Another H2 slide
+
+Content for the second H2 slide.
+
+## Third H2 slide
+
+More H2 content.
+
+---
+
+## H2 and H3 slide
+
+This is an H2 title.
+
+### H3 subtitle
+
+Content under H3.
+
+### Another H3 subtitle
+
+More content under H3.
+
+## Next H2 slide
+
+Another H2 slide.
+
+### H3 under next H2
+
+Content under this H3.
+
+---
+
+## H2, H3 and H4 slide
+
+This is an H2 title.
+
+### H3 subtitle
+
+Content under H3.
+
+#### H4 content
+
+This is H4 level content.
+
+#### Another H4 content
+
+More H4 level content.
+
+### Another H3 subtitle
+
+More content under H3.
+
+#### H4 under this H3
+
+H4 content here.
+
+## Next H2 slide
+
+Another H2 slide with mixed levels.
+
+---
+
+### H3 and H4 slide
+
+This is an H3 title.
+
+#### H4 subtitle
+
+Content under H4.
+
+#### Another H4 subtitle
+
+More content under H4.
+
+### Next H3 slide
+
+Another H3 slide.
+
+#### H4 under next H3
+
+Content under this H4.
+
+---
+
+## H2 and H4 slide (skipping H3)
+
+This is an H2 title.
+
+#### H4 content directly under H2
+
+This H4 is directly under H2, skipping H3 level.
+
+#### Another H4 content
+
+More H4 content without H3.
+
+## Next H2 slide
+
+Another H2 slide.
+
+#### Direct H4 again
+
+H4 content directly under H2.

--- a/testdata/heading.md.golden
+++ b/testdata/heading.md.golden
@@ -1,0 +1,443 @@
+[
+  {
+    "layout": "",
+    "titles": [
+      "Normal H1 only slide",
+      "Another H1 slide"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This is a slide with only H1 headings."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Content for the second H1 slide."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "layout": "",
+    "titles": [
+      "H1 and H2 slide",
+      "Next H1 slide"
+    ],
+    "subtitles": [
+      "H2 subtitle",
+      "Another H2 subtitle"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This is an H1 title."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Content under H2."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "More content under H2."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Another main slide."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "layout": "",
+    "titles": [
+      "H2 only slide",
+      "Another H2 slide",
+      "Third H2 slide"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This is a slide with only H2 headings."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Content for the second H2 slide."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "More H2 content."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "layout": "",
+    "titles": [
+      "H2 and H3 slide",
+      "Next H2 slide"
+    ],
+    "subtitles": [
+      "H3 subtitle",
+      "Another H3 subtitle",
+      "H3 under next H2"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This is an H2 title."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Content under H3."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "More content under H3."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Another H2 slide."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Content under this H3."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "layout": "",
+    "titles": [
+      "H2, H3 and H4 slide",
+      "Next H2 slide"
+    ],
+    "subtitles": [
+      "H3 subtitle",
+      "Another H3 subtitle"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This is an H2 title."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Content under H3."
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "H4 content"
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "This is H4 level content."
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "Another H4 content"
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "More H4 level content."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "More content under H3."
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "H4 under this H3"
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "H4 content here."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Another H2 slide with mixed levels."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "layout": "",
+    "titles": [
+      "H3 and H4 slide",
+      "Next H3 slide"
+    ],
+    "subtitles": [
+      "H4 subtitle",
+      "Another H4 subtitle",
+      "H4 under next H3"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This is an H3 title."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Content under H4."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "More content under H4."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Another H3 slide."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Content under this H4."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "layout": "",
+    "titles": [
+      "H2 and H4 slide (skipping H3)",
+      "Next H2 slide"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This is an H2 title."
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "H4 content directly under H2"
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "This H4 is directly under H2, skipping H3 level."
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "Another H4 content"
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "More H4 content without H3."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Another H2 slide."
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "Direct H4 again"
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "H4 content directly under H2."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
- Detect the minimum heading level in the document
- Use the detected level as title and level+1 as subtitle

close #187

There are almost no breaking changes! In fact, no changes have been made to existing test cases.