### PR TITLE
feat(apply): support setting title from frontmatter

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -85,8 +85,13 @@ var applyCmd = &cobra.Command{
 		}
 
 		if len(args) == 1 {
-			if presentationID == "" && markdownData.Frontmatter != nil && markdownData.Frontmatter.PresentationID != "" {
-				presentationID = markdownData.Frontmatter.PresentationID
+			if markdownData.Frontmatter != nil {
+				if presentationID == "" && markdownData.Frontmatter.PresentationID != "" {
+					presentationID = markdownData.Frontmatter.PresentationID
+				}
+				if title == "" && markdownData.Frontmatter.Title != "" {
+					title = markdownData.Frontmatter.Title
+				}
 			}
 		}
 

--- a/md/md.go
+++ b/md/md.go
@@ -38,7 +38,8 @@ type MD struct {
 
 // Frontmatter represents YAML frontmatter data.
 type Frontmatter struct {
-	PresentationID string `yaml:"presentationID,omitempty" json:"presentationID,omitempty"`
+	PresentationID string `yaml:"presentationID,omitempty" json:"presentationID,omitempty"` // ID of the Google Slides presentation
+	Title          string `yaml:"title,omitempty" json:"title,omitempty"`                   // title of the presentation
 }
 
 // Contents represents a collection of slide contents.


### PR DESCRIPTION
This pull request enhances the functionality of handling frontmatter in markdown files by introducing support for a `Title` field and improving the logic for extracting metadata. The changes ensure that both `PresentationID` and `Title` are properly utilized when processing markdown data.

### Enhancements to frontmatter handling:

* [`cmd/apply.go`](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fL88-R95): Updated the logic to check for and assign the `Title` field from the frontmatter if it is present and not empty. This complements the existing handling of `PresentationID`.

* [`md/md.go`](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517L41-R42): Added a new `Title` field to the `Frontmatter` struct, allowing markdown files to include and process a title for presentations.