### PR TITLE
Add automatic layout assignment based on heading levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,40 @@ The frontmatter must be:
 
 - `presentationID`: Google Slides presentation ID. When specified, you can use the simplified command syntax.
 - `title`: title of the presentation. When specified, you can use the simplified command syntax.
+- `layout`: Automatic layout assignment based on heading levels.
 
-Note: This feature is reserved for future enhancements.
+#### Automatic layout assignment
+
+You can specify layouts for different heading levels in the frontmatter. This automatically applies the appropriate layout to each slide based on its title heading level:
+
+```markdown
+---
+presentationID: xxxxxXXXXxxxxxXXXXxxxxxxxxxx
+title: My Presentation
+layout:
+  title: title-slide    # Layout for the first slide
+  h1: part              # Layout for H1 headings
+  h2: chapter           # Layout for H2 headings
+  h3: section           # Layout for H3 headings
+---
+
+# Part 1: Introduction
+Content for part slide...
+
+---
+
+## Chapter 1: Overview
+Content for chapter slide...
+
+---
+
+### Section 1.1: Details
+Content for section slide...
+```
+
+- The first slide uses the layout specified by `title`
+- Subsequent slides use layouts based on their heading level (`h1`, `h2`, `h3`, `h4`, `h5`, `h6`)
+- Explicit layout specifications via JSON comments (`<!-- {"layout": "custom"} -->`) take precedence over frontmatter settings
 
 ### Insertion rule
 

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -31,6 +31,7 @@ func TestParse(t *testing.T) {
 		{"../testdata/frontmatter.md"},
 		{"../testdata/autolink.md"},
 		{"../testdata/heading.md"},
+		{"../testdata/layout_by_heading.md"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {

--- a/testdata/layout_by_heading.md
+++ b/testdata/layout_by_heading.md
@@ -1,0 +1,53 @@
+---
+presentationID: your-presentation-id
+title: Example of Layout by Heading Level
+layout:
+  title: title-slide
+  h1: part
+  h2: chapter
+  h3: section
+  h4: subsection
+---
+
+# Presentation Title
+
+This is the first slide. It will use the "title-slide" layout if specified in the frontmatter.
+Without the "title" key in layout, it would use the default title layout.
+
+---
+
+# Part 1: Introduction
+
+This slide will automatically use the "part" layout because it has an H1 heading (and it's not the first slide).
+
+---
+
+## Chapter 1: Getting Started
+
+This slide will automatically use the "chapter" layout because it has an H2 heading.
+
+---
+
+### Section 1.1: Prerequisites
+
+This slide will automatically use the "section" layout because it has an H3 heading.
+
+---
+
+<!-- {"layout": "custom-layout"} -->
+
+## Chapter 2: Custom Layout
+
+Even with the frontmatter configuration, you can still override the layout for specific slides using the JSON comment syntax.
+
+---
+
+#### Subsection: Details
+
+This slide has an H4 heading. It will use the "subsection" layout from the frontmatter h4 mapping.
+
+---
+
+Content without a heading
+
+Slides without headings will use the default layout.

--- a/testdata/layout_by_heading.md.golden
+++ b/testdata/layout_by_heading.md.golden
@@ -1,0 +1,143 @@
+[
+  {
+    "layout": "title-slide",
+    "titles": [
+      "Presentation Title"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This is the first slide. It will use the \"title-slide\" layout if specified in the frontmatter.",
+                "softLineBreak": true
+              },
+              {
+                "value": "Without the \"title\" key in layout, it would use the default title layout."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "layout": "part",
+    "titles": [
+      "Part 1: Introduction"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This slide will automatically use the \"part\" layout because it has an H1 heading (and it's not the first slide)."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "layout": "chapter",
+    "titles": [
+      "Chapter 1: Getting Started"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This slide will automatically use the \"chapter\" layout because it has an H2 heading."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "layout": "section",
+    "titles": [
+      "Section 1.1: Prerequisites"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This slide will automatically use the \"section\" layout because it has an H3 heading."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "layout": "custom-layout",
+    "titles": [
+      "Chapter 2: Custom Layout"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Even with the frontmatter configuration, you can still override the layout for specific slides using the JSON comment syntax."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "layout": "subsection",
+    "titles": [
+      "Subsection: Details"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This slide has an H4 heading. It will use the \"subsection\" layout from the frontmatter h4 mapping."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "layout": "",
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Content without a heading"
+              }
+            ]
+          },
+          {
+            "fragments": [
+              {
+                "value": "Slides without headings will use the default layout."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Enable automatic slide layout selection through frontmatter configuration, eliminating the need for manual layout embedding in each slide. Users can now define layout mappings for heading levels (h1-h6) and title slides in YAML frontmatter, allowing structured markdown documents to automatically apply appropriate layouts based on their hierarchical structure.

Features:
- Frontmatter layout configuration
- Automatic layout application for title slide and heading levels H1-H6
- existing JSON comments take precedence over frontmatter settings for explicit control

This reduces manual layout specification overhead while ensuring consistent design patterns across large presentations, especially beneficial for structured content like parts, chapters, and sections.

Resolves #193