### PR TITLE
Change presentationID to presentation_id in YAML frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The slide pages are represented by dividing them with horizontal lines `---`.
 $ deck apply deck.md --presentation-id xxxxxXXXXxxxxxXXXXxxxxxxxxxx
 ```
 
-If your markdown file includes `presentationID` in the frontmatter, you can use the simplified syntax:
+If your markdown file includes `presentation_id` in the frontmatter, you can use the simplified syntax:
 
 ```console
 $ deck apply deck.md
@@ -93,7 +93,7 @@ This is useful during the content creation process as it allows you to see your 
 
 ```markdown
 ---
-presentationID: xxxxxXXXXxxxxxXXXXxxxxxxxxxx
+presentation_id: xxxxxXXXXxxxxxXXXXxxxxxxxxxx
 title: Talk about deck
 ---
 
@@ -106,13 +106,12 @@ The frontmatter must be:
 - At the very beginning of the file
 - Enclosed between `---` delimiters
 - Valid YAML syntax
+- Use `snake_case` for field names
 
 #### Available fields
 
-- `presentationID`: Google Slides presentation ID. When specified, you can use the simplified command syntax.
+- `presentation_id`: Google Slides presentation ID. When specified, you can use the simplified command syntax.
 - `title`: title of the presentation. When specified, you can use the simplified command syntax.
-
-Note: This feature is reserved for future enhancements.
 
 ### Insertion rule
 

--- a/md/md.go
+++ b/md/md.go
@@ -38,8 +38,8 @@ type MD struct {
 
 // Frontmatter represents YAML frontmatter data.
 type Frontmatter struct {
-	PresentationID string `yaml:"presentationID,omitempty" json:"presentationID,omitempty"` // ID of the Google Slides presentation
-	Title          string `yaml:"title,omitempty" json:"title,omitempty"`                   // title of the presentation
+	PresentationID string `yaml:"presentation_id,omitempty" json:"presentation_id,omitempty"` // ID of the Google Slides presentation
+	Title          string `yaml:"title,omitempty" json:"title,omitempty"`                     // title of the presentation
 }
 
 // Contents represents a collection of slide contents.


### PR DESCRIPTION
This is a breaking change, but the presentation ID feature was just introduced recently, so we don't provide backward compatibility for simplicity. While backward compatibility could be implemented, we chose to keep the code simple and clean.

This change unifies frontmatter field naming convention to snake_case, which improves consistency across all YAML frontmatter fields.

How do you think?

Changes:
- Update Frontmatter struct YAML tag from presentationID to presentation_id
- Update README examples and documentation to use presentation_id
- Clarify that frontmatter fields use snake_case naming

close #195