### PR TITLE
feat: Add {{output}} template variable support for code-block-to-image-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,29 +221,34 @@ There are three ways to receive code block information within the command:
 2. **Receive as environment variables**
    - `CODEBLOCK_LANG`: Optional language identifier of the code block (e.g., `go`, `python`)
    - `CODEBLOCK_CONTENT`: Content of the code block
+   - `CODEBLOCK_OUTPUT`: Path to a temporary output file
 
 3. **Receive with template syntax ( with [expr-lang](https://expr-lang.org/) )**
    - `{{lang}}`: Optional language identifier of the code block
    - `{{content}}`: Content of the code block
+   - `{{output}}`: Path to a temporary output file
    - `{{env.XXX}}`: Value of environment variable XXX
 
 These methods can be used in combination, and you can choose the appropriate method according to the command requirements.
+
+> [!NOTE]
+> When `{{output}}` is not specified, deck reads the image data from the command's stdout. When `{{output}}` is specified, the command should write the image to that file path, and deck will read the image data from that file.
 
 ##### Examples
 
 ```console
 # Convert Mermaid diagrams to images
-$ deck apply -c 'mmdc -i - -o output.png --quiet; cat output.png' -i xxxxxXXXXxxxxxXXXXxxxxxxxxxx deck.md
+$ deck apply -c 'mmdc -i - -o {{output}} --quiet' -i xxxxxXXXXxxxxxXXXXxxxxxxxxxx deck.md
 ```
 
 ```console
 # Generate code images with syntax highlighting (e.g., silicon)
-$ deck apply -c 'silicon -l {{lang == "" ? "md" : lang}} -o output.png; cat output.png' -i xxxxxXXXXxxxxxXXXXxxxxxxxxxx deck.md
+$ deck apply -c 'silicon -l {{lang == "" ? "md" : lang}} -o {{output}}' -i xxxxxXXXXxxxxxXXXXxxxxxxxxxx deck.md
 ```
 
 ```console
 # Use different tools depending on the language
-$ deck apply -c 'if [ {{lang}} = "mermaid" ]; then mmdc -i - -o output.png --quet; else silicon -l {{lang == "" ? "md" : lang}} --output output.png; fi; cat output.png' -i xxxxxXXXXxxxxxXXXXxxxxxxxxxx deck.md
+$ deck apply -c 'if [ {{lang}} = "mermaid" ]; then mmdc -i - -o {{output}} --quiet; else silicon -l {{lang == "" ? "md" : lang}} --output {{output}}; fi' -i xxxxxXXXXxxxxxXXXXxxxxxxxxxx deck.md
 ```
 
 ### Comment

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -1,8 +1,11 @@
 package md
 
 import (
+	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/tenntenn/golden"
@@ -52,6 +55,85 @@ func TestParse(t *testing.T) {
 			}
 			if diff := golden.Diff(t, "", tt.in, got); diff != "" {
 				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestGenCodeImage(t *testing.T) {
+	ctx := context.Background()
+
+	// Get absolute path to stub command
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stubCmd := filepath.Join(cwd, "testdata", "stub_code_img.go")
+
+	tests := []struct {
+		name                string
+		codeBlockToImageCmd string
+		codeBlock           *CodeBlock
+		wantErr             bool
+	}{
+		{
+			name:                "output to stdout",
+			codeBlockToImageCmd: "go run " + stubCmd,
+			codeBlock:           &CodeBlock{},
+		},
+		{
+			name:                "output to file using {{output}}",
+			codeBlockToImageCmd: "go run " + stubCmd + " -o {{output}}",
+			codeBlock:           &CodeBlock{},
+		},
+		{
+			name:                "template expansion with {{lang}} and {{content}}",
+			codeBlockToImageCmd: "go run " + stubCmd + " -o {{output}} && echo '{{lang}}: {{content}}' > /dev/null",
+			codeBlock: &CodeBlock{
+				Language: "javascript",
+				Content:  "console.log('test')",
+			},
+		},
+		{
+			name:                "command failure",
+			codeBlockToImageCmd: "false",
+			codeBlock:           &CodeBlock{},
+			wantErr:             true,
+		},
+		{
+			name:                "invalid command",
+			codeBlockToImageCmd: "this-command-does-not-exist",
+			codeBlock:           &CodeBlock{},
+			wantErr:             true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			img, err := genCodeImage(ctx, tt.codeBlockToImageCmd, tt.codeBlock)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("genCodeImage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				if img == nil {
+					t.Error("genCodeImage() returned nil image without error")
+					return
+				}
+
+				// Check that image data is not empty
+				imgData := img.Bytes()
+				pngHeader := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+				if len(imgData) < len(pngHeader) {
+					t.Error("genCodeImage() returned insufficient image data")
+				}
+
+				// For PNG images, verify basic structure
+				if !reflect.DeepEqual(imgData[:len(pngHeader)], pngHeader) {
+					t.Error("genCodeImage() did not return valid PNG data")
+				}
 			}
 		})
 	}

--- a/md/testdata/stub_code_img.go
+++ b/md/testdata/stub_code_img.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+)
+
+func main() {
+	var output string
+	flag.StringVar(&output, "o", "", "output file path")
+	flag.Parse()
+
+	// Create a 1x1 pixel stub PNG image
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.RGBA{255, 0, 0, 255}) // Red pixel
+
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		fmt.Fprintf(os.Stderr, "Error encoding PNG: %v\n", err)
+		os.Exit(1)
+	}
+
+	if output != "" {
+		// Write to file
+		if err := os.WriteFile(output, buf.Bytes(), 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing file: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		// Write to stdout
+		if _, err := os.Stdout.Write(buf.Bytes()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing to stdout: %v\n", err)
+			os.Exit(1)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Added support for `{{output}}` template variable in `--code-block-to-image-command`
- Refactored code block image generation logic into the `genCodeImage` function
- Maintained backward compatibility by using stdout when the output file is not created

## Changes
- Extract image generation logic from the `ToSlides` method into a standalone `genCodeImage` function
- Add `{{output}}` template variable that expands to a temporary file path
- Set `CODEBLOCK_OUTPUT` environment variable for consistency
- Add comprehensive tests using a stub image generator

close #203 