### PR TITLE
feat(md): add support for block quotes

### DIFF
--- a/md/md_test.go
+++ b/md/md_test.go
@@ -34,6 +34,7 @@ func TestParse(t *testing.T) {
 		{"../testdata/frontmatter.md"},
 		{"../testdata/autolink.md"},
 		{"../testdata/heading.md"},
+		{"../testdata/blockquote.md"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {

--- a/slide.go
+++ b/slide.go
@@ -23,13 +23,14 @@ import (
 type Slides []*Slide
 
 type Slide struct {
-	Layout      string   `json:"layout"`
-	Freeze      bool     `json:"freeze,omitempty"`
-	Titles      []string `json:"titles,omitempty"`
-	Subtitles   []string `json:"subtitles,omitempty"`
-	Bodies      []*Body  `json:"bodies,omitempty"`
-	Images      []*Image `json:"images,omitempty"`
-	SpeakerNote string   `json:"speakerNote,omitempty"`
+	Layout      string        `json:"layout"`
+	Freeze      bool          `json:"freeze,omitempty"`
+	Titles      []string      `json:"titles,omitempty"`
+	Subtitles   []string      `json:"subtitles,omitempty"`
+	Bodies      []*Body       `json:"bodies,omitempty"`
+	Images      []*Image      `json:"images,omitempty"`
+	BlockQuotes []*BlockQuote `json:"blockQuotes,omitempty"`
+	SpeakerNote string        `json:"speakerNote,omitempty"`
 
 	new    bool
 	delete bool
@@ -56,6 +57,11 @@ type Fragment struct {
 	Code          bool   `json:"code,omitempty"`
 	SoftLineBreak bool   `json:"softLineBreak,omitempty"`
 	ClassName     string `json:"className,omitempty"`
+}
+
+type BlockQuote struct {
+	Paragraphs []*Paragraph `json:"paragraphs,omitempty"`
+	Nesting    int          `json:"nesting,omitempty"`
 }
 
 // Bullet represents the type of bullet point for a paragraph.

--- a/testdata/blockquote.md
+++ b/testdata/blockquote.md
@@ -1,0 +1,17 @@
+# Block Quote
+
+---
+
+# Block Quotes
+
+> NOTICE!
+> Hello **World!**
+
+This is paragraph.
+
+> WARNING!
+> Hello **Space!**
+> > NESTED!
+> > But flatten
+> > > NESTED NESTED!
+> > > But flatten

--- a/testdata/blockquote.md.golden
+++ b/testdata/blockquote.md.golden
@@ -1,0 +1,111 @@
+[
+  {
+    "layout": "",
+    "titles": [
+      "Block Quote"
+    ]
+  },
+  {
+    "layout": "",
+    "titles": [
+      "Block Quotes"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This is paragraph."
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "block_quotes": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "NOTICE"
+              },
+              {
+                "value": "!",
+                "softLineBreak": true
+              },
+              {
+                "value": "Hello "
+              },
+              {
+                "value": "World!",
+                "bold": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "WARNING"
+              },
+              {
+                "value": "!",
+                "softLineBreak": true
+              },
+              {
+                "value": "Hello "
+              },
+              {
+                "value": "Space!",
+                "bold": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "NESTED"
+              },
+              {
+                "value": "!",
+                "softLineBreak": true
+              },
+              {
+                "value": "But flatten"
+              }
+            ]
+          }
+        ],
+        "nesting": 1
+      },
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "NESTED NESTED"
+              },
+              {
+                "value": "!",
+                "softLineBreak": true
+              },
+              {
+                "value": "But flatten"
+              }
+            ]
+          }
+        ],
+        "nesting": 2
+      }
+    ]
+  }
+]


### PR DESCRIPTION
ref: #202 

This pull request introduces support for parsing and handling block quotes in markdown content, along with updates to the `deck` package to accommodate this new feature. The changes include modifications to the `Content` and `Slide` structures, the addition of a new `BlockQuote` type, and updates to the parsing logic and tests.

### Parsing and handling block quotes:

* [`md/md.go`](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R68): Added a `BlockQuotes` field to the `Content` struct and updated the `ParseContent` function to parse block quotes, flatten nested block quotes, and include them in the `Content` structure. [[1]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R68) [[2]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R164-R225) [[3]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R350-L348)
* [`slide.go`](diffhunk://#diff-9b512ff450c4d8f204d811a69ae2ed95048d738c05504738d77a91bf3e9ade7cR32): Added a `BlockQuotes` field to the `Slide` struct and defined a new `BlockQuote` type with `Paragraphs` and `Nesting` fields to represent block quotes. [[1]](diffhunk://#diff-9b512ff450c4d8f204d811a69ae2ed95048d738c05504738d77a91bf3e9ade7cR32) [[2]](diffhunk://#diff-9b512ff450c4d8f204d811a69ae2ed95048d738c05504738d77a91bf3e9ade7cR62-R66)

### Test updates:

* [`md/md_test.go`](diffhunk://#diff-a875d3534d9727c49cb3453f84caac0054354cf1d674fd78fd638afc7593ecf8R37): Added a new test case for block quotes using the `blockquote.md` test data file.
* [`testdata/blockquote.md`](diffhunk://#diff-6176bbe228f625b4dc38601d10bdf8132ce87feb0c0885ecd852165d03a97c12R1-R17): Created a markdown file with various block quote examples, including nested block quotes.
* [`testdata/blockquote.md.golden`](diffhunk://#diff-b30a46d47d74e2d20c3df592cc840d8ab0854f737793431e5cb7398cc14ade32R1-R111): Added the expected output for the block quote test case, including flattened nested block quotes with appropriate `Nesting` values.