### PR TITLE
feat: Add ignore page functionality with page configuration comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,17 @@ It is possible to skip the operation of the target page.
 <!-- {"freeze": true} -->
 ```
 
+### `"ignore":`
+
+It is possible to exclude the target page from slide generation.
+
+> [!TIP]
+> Use this for draft pages, notes, or content that you don't want to include in the presentation.
+
+```markdown
+<!-- {"ignore": true} -->
+```
+
 ## Integration
 
 - [zonuexe/deck-slides.el](https://github.com/zonuexe/deck-slides.el) ... Creating deck using Markdown and Google Slides.

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -35,6 +35,7 @@ func TestParse(t *testing.T) {
 		{"../testdata/autolink.md"},
 		{"../testdata/heading.md"},
 		{"../testdata/blockquote.md"},
+		{"../testdata/ignore.md"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {

--- a/testdata/ignore.md
+++ b/testdata/ignore.md
@@ -1,0 +1,33 @@
+# First Slide
+
+This slide will be included.
+
+---
+
+# Second Slide - Ignored
+
+<!-- {"ignore": true} -->
+
+This slide will be ignored and not included in the presentation.
+
+---
+
+# Third Slide
+
+This slide will be included again.
+
+---
+
+# Fourth Slide - Also Ignored
+
+<!-- {"ignore": true} -->
+
+Another slide that should be ignored.
+
+Some more content here.
+
+---
+
+# Fifth Slide
+
+Final slide that will be included.

--- a/testdata/ignore.md.golden
+++ b/testdata/ignore.md.golden
@@ -1,0 +1,59 @@
+[
+  {
+    "layout": "",
+    "titles": [
+      "First Slide"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This slide will be included."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "layout": "",
+    "titles": [
+      "Third Slide"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "This slide will be included again."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "layout": "",
+    "titles": [
+      "Fifth Slide"
+    ],
+    "bodies": [
+      {
+        "paragraphs": [
+          {
+            "fragments": [
+              {
+                "value": "Final slide that will be included."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
- Support `<!-- {"ignore": true} -->` syntax to exclude pages from slide generation

This allows users to exclude draft pages, notes, or unwanted content from presentations while keeping them in the markdown file.

resolve #211