### PR TITLE
fix: rename JSON field names to use snake_case

### DIFF
--- a/slide.go
+++ b/slide.go
@@ -30,8 +30,8 @@ type Slide struct {
 	Subtitles   []string      `json:"subtitles,omitempty"`
 	Bodies      []*Body       `json:"bodies,omitempty"`
 	Images      []*Image      `json:"images,omitempty"`
-	BlockQuotes []*BlockQuote `json:"blockQuotes,omitempty"`
-	SpeakerNote string        `json:"speakerNote,omitempty"`
+	BlockQuotes []*BlockQuote `json:"block_quotes,omitempty"`
+	SpeakerNote string        `json:"speaker_note,omitempty"`
 
 	new    bool
 	delete bool
@@ -56,8 +56,8 @@ type Fragment struct {
 	Italic        bool   `json:"italic,omitempty"`
 	Link          string `json:"link,omitempty"`
 	Code          bool   `json:"code,omitempty"`
-	SoftLineBreak bool   `json:"softLineBreak,omitempty"`
-	ClassName     string `json:"className,omitempty"`
+	SoftLineBreak bool   `json:"soft_line_break,omitempty"`
+	ClassName     string `json:"class_name,omitempty"`
 }
 
 type BlockQuote struct {

--- a/testdata/blockquote.md.golden
+++ b/testdata/blockquote.md.golden
@@ -33,7 +33,7 @@
               },
               {
                 "value": "!",
-                "softLineBreak": true
+                "soft_line_break": true
               },
               {
                 "value": "Hello "
@@ -55,7 +55,7 @@
               },
               {
                 "value": "!",
-                "softLineBreak": true
+                "soft_line_break": true
               },
               {
                 "value": "Hello "
@@ -77,7 +77,7 @@
               },
               {
                 "value": "!",
-                "softLineBreak": true
+                "soft_line_break": true
               },
               {
                 "value": "But flatten"
@@ -96,7 +96,7 @@
               },
               {
                 "value": "!",
-                "softLineBreak": true
+                "soft_line_break": true
               },
               {
                 "value": "But flatten"

--- a/testdata/list_and_paragraph.md.golden
+++ b/testdata/list_and_paragraph.md.golden
@@ -44,11 +44,11 @@
               {
                 "value": "C",
                 "bold": true,
-                "softLineBreak": true
+                "soft_line_break": true
               },
               {
                 "value": "D",
-                "softLineBreak": true
+                "soft_line_break": true
               },
               {
                 "value": "E"

--- a/testdata/paragraph_and_list.md.golden
+++ b/testdata/paragraph_and_list.md.golden
@@ -12,7 +12,7 @@
               {
                 "value": "C",
                 "bold": true,
-                "softLineBreak": true
+                "soft_line_break": true
               },
               {
                 "value": "D"

--- a/testdata/style.md.golden
+++ b/testdata/style.md.golden
@@ -68,7 +68,7 @@
               },
               {
                 "value": "notice",
-                "className": "notice"
+                "class_name": "notice"
               }
             ],
             "bullet": "-"
@@ -77,7 +77,7 @@
             "fragments": [
               {
                 "value": "unknown",
-                "className": "unknown"
+                "class_name": "unknown"
               },
               {
                 "value": " world"
@@ -89,7 +89,7 @@
             "fragments": [
               {
                 "value": "unknown",
-                "className": "unknown"
+                "class_name": "unknown"
               },
               {
                 "value": " world"


### PR DESCRIPTION
This pull request updates JSON field names in `slide.go` and associated test data files to use snake_case instead of camelCase for consistency. The changes primarily affect the `Slide` and `Fragment` structs and their corresponding test files.

### Struct field updates:

* [`slide.go`](diffhunk://#diff-9b512ff450c4d8f204d811a69ae2ed95048d738c05504738d77a91bf3e9ade7cL33-R34): Updated JSON field names in `Slide` struct (`blockQuotes` → `block_quotes`, `speakerNote` → `speaker_note`) and `Fragment` struct (`softLineBreak` → `soft_line_break`, `className` → `class_name`). [[1]](diffhunk://#diff-9b512ff450c4d8f204d811a69ae2ed95048d738c05504738d77a91bf3e9ade7cL33-R34) [[2]](diffhunk://#diff-9b512ff450c4d8f204d811a69ae2ed95048d738c05504738d77a91bf3e9ade7cL59-R60)

### Test data adjustments:

* [`testdata/blockquote.md.golden`](diffhunk://#diff-b30a46d47d74e2d20c3df592cc840d8ab0854f737793431e5cb7398cc14ade32L36-R36): Updated field names (`softLineBreak` → `soft_line_break`) in multiple locations to match the updated `Fragment` struct. [[1]](diffhunk://#diff-b30a46d47d74e2d20c3df592cc840d8ab0854f737793431e5cb7398cc14ade32L36-R36) [[2]](diffhunk://#diff-b30a46d47d74e2d20c3df592cc840d8ab0854f737793431e5cb7398cc14ade32L58-R58) [[3]](diffhunk://#diff-b30a46d47d74e2d20c3df592cc840d8ab0854f737793431e5cb7398cc14ade32L80-R80) [[4]](diffhunk://#diff-b30a46d47d74e2d20c3df592cc840d8ab0854f737793431e5cb7398cc14ade32L99-R99)
* [`testdata/list_and_paragraph.md.golden`](diffhunk://#diff-4f6ce6a509cc0dde0ed9f9e83d1564759d492fe622b3848c91e9642cf434a805L47-R51): Adjusted field names (`softLineBreak` → `soft_line_break`) for consistency with `Fragment`.
* [`testdata/paragraph_and_list.md.golden`](diffhunk://#diff-c8e9d7f14ca5fa67eda1328a26c6a542f58398b4db2f7a26876586da17f727dcL15-R15): Renamed `softLineBreak` to `soft_line_break` in test cases.
* [`testdata/style.md.golden`](diffhunk://#diff-f6a68ab325b985f899164fc1b927a8c5ff8237d86bf7acfb99306abcf17f3770L71-R71): Changed `className` to `class_name` in multiple test cases to align with the updated `Fragment` struct. [[1]](diffhunk://#diff-f6a68ab325b985f899164fc1b927a8c5ff8237d86bf7acfb99306abcf17f3770L71-R71) [[2]](diffhunk://#diff-f6a68ab325b985f899164fc1b927a8c5ff8237d86bf7acfb99306abcf17f3770L80-R80) [[3]](diffhunk://#diff-f6a68ab325b985f899164fc1b927a8c5ff8237d86bf7acfb99306abcf17f3770L92-R92)