### PR TITLE
fix: add proper paragraph separation in slides

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -876,11 +876,8 @@ func (d *Deck) applyPage(ctx context.Context, index int, slide *Slide) (err erro
 			}
 
 			if len(body.Paragraphs) > j+1 {
-				nextParagraph := body.Paragraphs[j+1]
-				if paragraph.Bullet != nextParagraph.Bullet || paragraph.Bullet != BulletNone {
-					text += "\n"
-					plen++
-				}
+				text += "\n"
+				plen++
 			}
 
 			if paragraph.Bullet != BulletNone {


### PR DESCRIPTION
Fixes #217 by ensuring paragraphs separated by blank lines in markdown maintain proper visual separation in Google Slides.

I simply removed the `if` branch, but judging from the discussion in #217, it does not seem to be such a simple problem.

Paragraph separation worked in my environment, but please let me know if this fix causes any problems or has any impact.