### PR TITLE
fix: improve single-character list item rendering

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -919,7 +919,7 @@ func (d *Deck) applyPage(ctx context.Context, index int, slide *Slide) (err erro
 		for _, r := range bulletRangeSlice {
 			startIndex := int64(r.start)
 			endIndex := int64(r.end - 1)
-			if startIndex == endIndex {
+			if startIndex <= endIndex {
 				endIndex++
 			}
 			req.Requests = append(req.Requests, &slides.Request{


### PR DESCRIPTION
Fixes #219 by making the bullet range condition more robust, but I am not sure if these fixes are correct.

With this fix, I've confirmed that the list is rendered correctly.

The following corrections seem to be related.

https://github.com/k1LoW/deck/pull/111