### PR TITLE
feat(cmd): add markdown file support to deck new command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ $ deck new --from yyyyyyyYYYYyYYYYYYYyyyyyyyyy --title "Talk about deck"
 xxxxxXXXXxxxxxXXXXxxxxxxxxxx
 ```
 
+You can also specify a markdown file:
+
+```console
+$ deck new presentation.md --title "Talk about deck"
+Applied frontmatter to presentation.md
+xxxxxXXXXxxxxxXXXXxxxxxxxxxx
+```
+
+This will create (or update) the specified markdown file with frontmatter containing the presentation ID and title.
+
 ### Write desk in markdown
 
 The slide pages are represented by dividing them with horizontal lines `---`.

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -25,15 +25,20 @@ import (
 	"fmt"
 
 	"github.com/k1LoW/deck"
+	"github.com/k1LoW/deck/md"
 	"github.com/spf13/cobra"
 )
 
 var from string
 
 var newCmd = &cobra.Command{
-	Use:   "new",
+	Use:   "new [markdown-file]",
 	Short: "create new presentation",
-	Long:  `create new presentation.`,
+	Long: `create new presentation.
+
+If a markdown file is specified, frontmatter with title and presentationId will be added to the file.
+If the file doesn't exist, it will be created.`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		var (
@@ -56,7 +61,18 @@ var newCmd = &cobra.Command{
 				return err
 			}
 		}
-		fmt.Println(d.ID())
+
+		presentationID := d.ID()
+
+		// If markdown file is specified, apply frontmatter to it.
+		if len(args) > 0 {
+			mdFile := args[0]
+			if err := md.ApplyFrontmatterToMD(mdFile, title, presentationID); err != nil {
+				return err
+			}
+			cmd.PrintErrf("Applied frontmatter to %s\n", mdFile)
+		}
+		fmt.Println(presentationID)
 		return nil
 	},
 }

--- a/md/frontmatter.go
+++ b/md/frontmatter.go
@@ -1,0 +1,82 @@
+package md
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/goccy/go-yaml"
+	"github.com/k1LoW/errors"
+)
+
+// ApplyFrontmatterToMD updates or creates a markdown file with frontmatter
+func ApplyFrontmatterToMD(mdFile, title, presentationID string) (err error) {
+	defer func() {
+		err = errors.WithStack(err)
+	}()
+
+	// Read existing content or create empty content
+	var content []byte
+	if c, err := os.ReadFile(mdFile); err == nil {
+		content = c
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	const fmSep = "---\n"
+
+	// Check if content starts with frontmatter
+	var frontmatter = make(map[string]any)
+	var bodyContent = content
+
+	if bytes.HasPrefix(content, []byte(fmSep)) {
+		// May have frontmatter, parse it
+		stuffs := bytes.SplitN(content, []byte(fmSep), 3)
+		if len(stuffs) == 3 {
+			maybeFrontmatter := stuffs[1]
+			maybeBody := stuffs[2]
+			var fm = make(map[string]any)
+			if err := yaml.Unmarshal(maybeFrontmatter, &fm); err == nil {
+				frontmatter = fm
+				bodyContent = maybeBody
+			}
+		}
+	}
+
+	// Update frontmatter fields
+	if title != "" {
+		frontmatter["title"] = title
+	}
+	frontmatter["presentationId"] = presentationID
+
+	// Marshal frontmatter back to YAML
+	frontmatterYAML, err := yaml.Marshal(frontmatter)
+	if err != nil {
+		return fmt.Errorf("failed to encode frontmatter: %w", err)
+	}
+	// Remove trailing newline from YAML output if present
+	frontmatterYAML = bytes.TrimSpace(frontmatterYAML)
+
+	// Combine frontmatter and body
+	var newContent bytes.Buffer
+	newContent.WriteString(fmSep)
+	newContent.Write(frontmatterYAML)
+	newContent.WriteString("\n")
+	if !bytes.HasPrefix(bodyContent, []byte(fmSep)) {
+		newContent.WriteString(fmSep)
+	}
+	newContent.Write(bodyContent)
+
+	dir := filepath.Dir(mdFile)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory: %w", err)
+		}
+	}
+	// Write the file
+	if err := os.WriteFile(mdFile, newContent.Bytes(), 0644); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+	return nil
+}

--- a/md/frontmatter_test.go
+++ b/md/frontmatter_test.go
@@ -1,6 +1,9 @@
 package md
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -94,5 +97,124 @@ tags:
 			// Since Frontmatter is an empty struct, just verify it's not nil when expected
 			// All YAML fields are ignored, so no field comparison needed
 		})
+	}
+}
+
+func TestApplyFrontmatterToMD(t *testing.T) {
+	tests := []struct {
+		name            string
+		initialContent  string
+		title           string
+		presentationID  string
+		expectedContent string
+	}{
+		{
+			name:           "new file without frontmatter",
+			initialContent: "",
+			title:          "Test Title",
+			presentationID: "test-id-123",
+			expectedContent: `---
+presentationId: test-id-123
+title: Test Title
+---
+`,
+		},
+		{
+			name: "existing file without frontmatter",
+			initialContent: `# My Presentation
+
+This is the content.`,
+			title:          "Test Title",
+			presentationID: "test-id-123",
+			expectedContent: `---
+presentationId: test-id-123
+title: Test Title
+---
+# My Presentation
+
+This is the content.`,
+		},
+		{
+			name: "existing file with frontmatter",
+			initialContent: `---
+author: John Doe
+date: 2023-01-01
+---
+# My Presentation`,
+			title:          "Updated Title",
+			presentationID: "new-id-456",
+			expectedContent: `---
+author: John Doe
+date: "2023-01-01"
+presentationId: new-id-456
+title: Updated Title
+---
+# My Presentation`,
+		},
+		{
+			name: "existing file with frontmatter - update presentationId only",
+			initialContent: `---
+title: Existing Title
+presentationId: old-id
+---
+# Content`,
+			title:          "",
+			presentationID: "new-id-789",
+			expectedContent: `---
+presentationId: new-id-789
+title: Existing Title
+---
+# Content`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp file
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "test.md")
+
+			// Write initial content if any
+			if tt.initialContent != "" {
+				if err := os.WriteFile(tmpFile, []byte(tt.initialContent), 0644); err != nil {
+					t.Fatalf("Failed to write initial content: %v", err)
+				}
+			}
+
+			// Run the function
+			err := ApplyFrontmatterToMD(tmpFile, tt.title, tt.presentationID)
+			if err != nil {
+				t.Fatalf("ApplyFrontmatterToMD failed: %v", err)
+			}
+
+			// Read the result
+			content, err := os.ReadFile(tmpFile)
+			if err != nil {
+				t.Fatalf("Failed to read result: %v", err)
+			}
+
+			// Compare normalized content (trim spaces and normalize line endings)
+			got := strings.TrimSpace(string(content))
+			want := strings.TrimSpace(tt.expectedContent)
+
+			if got != want {
+				t.Errorf("Content mismatch:\nGot:\n%s\n\nWant:\n%s", got, want)
+			}
+		})
+	}
+}
+
+func TestApplyFrontmatterToMD_CreateDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	nestedFile := filepath.Join(tmpDir, "nested", "dir", "test.md")
+
+	err := ApplyFrontmatterToMD(nestedFile, "Test", "test-id")
+	if err != nil {
+		t.Fatalf("Failed to create nested directory: %v", err)
+	}
+
+	// Check if file exists
+	if _, err := os.Stat(nestedFile); os.IsNotExist(err) {
+		t.Errorf("File was not created: %s", nestedFile)
 	}
 }


### PR DESCRIPTION
Add optional markdown filename argument to `deck new` command that automatically creates or updates the file with frontmatter containing title and presentationId.

Changes:
- Accept optional markdown filename as first argument in cmd/new.go
- Create file and parent directories if they don't exist
- Parse and preserve existing frontmatter fields when updating
- Add or update title and presentationId fields

Usage:
  deck new presentation.md --title "My Presentation"

This simplifies the workflow by combining presentation creation and markdown file setup in a single command.