### PR TITLE
chore: set User-Agent to HTTP Request for crawling manner

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/k1LoW/deck/config"
+	"github.com/k1LoW/deck/version"
 	"github.com/k1LoW/errors"
 	"github.com/pkg/browser"
 	"golang.org/x/oauth2"
@@ -32,6 +33,8 @@ import (
 )
 
 var _ retryablehttp.LeveledLogger = (*slog.Logger)(nil)
+
+var userAgent = "k1LoW-deck/" + version.Version + " (+https://github.com/Songmu/k1LoW/deck)"
 
 const (
 	layoutNameForStyle           = "style"
@@ -242,11 +245,13 @@ func (d *Deck) initialize(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+	srv.UserAgent = userAgent
 	d.srv = srv
 	driveSrv, err := drive.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return err
 	}
+	driveSrv.UserAgent = userAgent
 	d.driveSrv = driveSrv
 	return nil
 }

--- a/slide.go
+++ b/slide.go
@@ -113,8 +113,12 @@ func NewImage(pathOrURL string) (_ *Image, err error) {
 		client := &http.Client{
 			Timeout: 30 * time.Second,
 		}
-
-		res, err := client.Get(pathOrURL)
+		req, err := http.NewRequest("GET", pathOrURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch image from URL %s: %w", pathOrURL, err)
+		}
+		req.Header.Set("User-Agent", userAgent)
+		res, err := client.Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch image from URL %s: %w", pathOrURL, err)
 		}


### PR DESCRIPTION
Since the deck accesses external URLs to some extent, it is recommended to set the User-Agent just in case.