### PR TITLE
fix(compare): move comparison logic to a new file and simplify equality check

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -1,0 +1,188 @@
+package deck
+
+import (
+	"bytes"
+	"encoding/json"
+	"slices"
+)
+
+func (s *Slide) Compare(other *Slide) bool {
+	if s == nil || other == nil {
+		return s == other
+	}
+	if s.Layout != other.Layout {
+		return false
+	}
+	if !titlesEqual(s.Titles, other.Titles) {
+		return false
+	}
+	if !subtitlesEqual(s.Subtitles, other.Subtitles) {
+		return false
+	}
+	if !bodiesEqual(s.Bodies, other.Bodies) {
+		return false
+	}
+	if !imagesEqual(s.Images, other.Images) {
+		return false
+	}
+	if !blockQuotesEqual(s.BlockQuotes, other.BlockQuotes) {
+		return false
+	}
+	if s.SpeakerNote != other.SpeakerNote {
+		return false
+	}
+	return true
+}
+
+func slidesEqual(slide1, slide2 *Slide) bool {
+	return slide1.Compare(slide2)
+}
+
+func titlesEqual(titles1, titles2 []string) bool {
+	if len(titles1) != len(titles2) {
+		return false
+	}
+	for i := range titles1 {
+		if titles1[i] != titles2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func subtitlesEqual(subtitles1, subtitles2 []string) bool {
+	if len(subtitles1) != len(subtitles2) {
+		return false
+	}
+	for i := range subtitles1 {
+		if subtitles1[i] != subtitles2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func bodiesEqual(bodies1, bodies2 []*Body) bool {
+	if len(bodies1) != len(bodies2) {
+		return false
+	}
+	for i, body1 := range bodies1 {
+		body2 := bodies2[i]
+		if body1 == nil || body2 == nil {
+			if body1 != body2 {
+				return false
+			}
+		}
+		if !paragraphsEqual(body1.Paragraphs, body2.Paragraphs) {
+			return false
+		}
+	}
+	return true
+}
+
+func imagesEqual(images1, images2 []*Image) bool {
+	if len(images1) != len(images2) {
+		return false
+	}
+	slices.SortFunc(images1, func(a *Image, b *Image) int {
+		return int(a.Checksum()) - int(b.Checksum())
+	})
+	slices.SortFunc(images2, func(a *Image, b *Image) int {
+		return int(a.Checksum()) - int(b.Checksum())
+	})
+	for i, img := range images1 {
+		if !img.Compare(images2[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func blockQuotesEqual(blockQuotes1, blockQuotes2 []*BlockQuote) bool {
+	if len(blockQuotes1) != len(blockQuotes2) {
+		return false
+	}
+	for i, bq1 := range blockQuotes1 {
+		bq2 := blockQuotes2[i]
+		if bq1 == nil || bq2 == nil {
+			if bq1 != bq2 {
+				return false
+			}
+		}
+		if bq1.Nesting != bq2.Nesting {
+			return false
+		}
+		if !paragraphsEqual(bq1.Paragraphs, bq2.Paragraphs) {
+			return false
+		}
+	}
+	return true
+}
+
+func paragraphEqual(paragraph1, paragraph2 *Paragraph) bool {
+	if paragraph1 == nil || paragraph2 == nil {
+		return paragraph1 == paragraph2
+	}
+	if paragraph1.Bullet != paragraph2.Bullet {
+		return false
+	}
+	if paragraph1.Nesting != paragraph2.Nesting {
+		return false
+	}
+	merged1B, err := json.Marshal(mergeFragments(paragraph1.Fragments))
+	if err != nil {
+		return false
+	}
+	merged2B, err := json.Marshal(mergeFragments(paragraph2.Fragments))
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(merged1B, merged2B)
+}
+
+func paragraphsEqual(paragraphs1, paragraphs2 []*Paragraph) bool {
+	if len(paragraphs1) != len(paragraphs2) {
+		return false
+	}
+	for i, paragraph1 := range paragraphs1 {
+		paragraph2 := paragraphs2[i]
+		if !paragraphEqual(paragraph1, paragraph2) {
+			return false
+		}
+	}
+	return true
+}
+
+func mergeFragments(in []*Fragment) []*Fragment {
+	var merged []*Fragment
+	if len(in) == 0 {
+		return merged
+	}
+	for i := range len(in) {
+		value := in[i].Value
+		if in[i].SoftLineBreak {
+			value += "\n"
+		}
+		if i > 0 {
+			// Merge with previous fragment if possible
+			if in[i-1].Bold == in[i].Bold &&
+				in[i-1].Italic == in[i].Italic &&
+				in[i-1].Link == in[i].Link &&
+				in[i-1].Code == in[i].Code &&
+				in[i-1].ClassName == in[i].ClassName {
+				merged[len(merged)-1].Value += value
+				continue
+			}
+		}
+		merged = append(merged, &Fragment{
+			Value:         in[i].Value,
+			Bold:          in[i].Bold,
+			Italic:        in[i].Italic,
+			Link:          in[i].Link,
+			Code:          in[i].Code,
+			SoftLineBreak: false,
+			ClassName:     in[i].ClassName,
+		})
+	}
+	return merged
+}

--- a/deck.go
+++ b/deck.go
@@ -1197,6 +1197,7 @@ func (d *Deck) applyParagraphsRequests(objectID string, paragraphs []*Paragraph)
 	currentBullet := BulletNone
 	for j, paragraph := range paragraphs {
 		plen := 0
+		startIndex := count
 		if paragraph.Bullet != BulletNone {
 			if paragraph.Nesting > 0 {
 				text += strings.Repeat("\t", paragraph.Nesting)
@@ -1204,24 +1205,26 @@ func (d *Deck) applyParagraphsRequests(objectID string, paragraphs []*Paragraph)
 			}
 		}
 		for _, fragment := range paragraph.Fragments {
+			fValue := fragment.Value
 			flen := countString(fragment.Value)
 			for _, req := range d.getInlineStyleRequests(fragment) {
 				req.ObjectId = objectID
 				req.TextRange = &slides.Range{
 					Type:       "FIXED_RANGE",
-					StartIndex: ptrInt64(count),
-					EndIndex:   ptrInt64(count + int64(flen)),
+					StartIndex: ptrInt64(startIndex),
+					EndIndex:   ptrInt64(startIndex + int64(flen)),
 				}
 				styleReqs = append(styleReqs, &slides.Request{
 					UpdateTextStyle: req,
 				})
 			}
-			plen += flen
-			text += fragment.Value
 			if fragment.SoftLineBreak {
-				text += "\n"
-				plen++
+				fValue += "\n"
+				flen++
 			}
+			plen += flen
+			text += fValue
+			startIndex += int64(flen)
 		}
 
 		if len(paragraphs) > j+1 {

--- a/deck.go
+++ b/deck.go
@@ -1184,7 +1184,7 @@ func (d *Deck) refresh(ctx context.Context) (err error) {
 	return nil
 }
 
-func (d *Deck) applyParagraphsRequests(objectID string, paragraphs []*Paragraph) (reqs []*slides.Request, stlyeReqs []*slides.Request, err error) {
+func (d *Deck) applyParagraphsRequests(objectID string, paragraphs []*Paragraph) (reqs []*slides.Request, styleReqs []*slides.Request, err error) {
 	defer func() {
 		err = errors.WithStack(err)
 	}()
@@ -1194,7 +1194,6 @@ func (d *Deck) applyParagraphsRequests(objectID string, paragraphs []*Paragraph)
 	text := ""
 	bulletStartIndex := int64(0) // reset per body
 	bulletEndIndex := int64(0)   // reset per body
-	var styleReqs []*slides.Request
 	currentBullet := BulletNone
 	for j, paragraph := range paragraphs {
 		plen := 0
@@ -1213,7 +1212,7 @@ func (d *Deck) applyParagraphsRequests(objectID string, paragraphs []*Paragraph)
 					StartIndex: ptrInt64(count),
 					EndIndex:   ptrInt64(count + int64(flen)),
 				}
-				stlyeReqs = append(stlyeReqs, &slides.Request{
+				styleReqs = append(styleReqs, &slides.Request{
 					UpdateTextStyle: req,
 				})
 			}
@@ -1271,7 +1270,7 @@ func (d *Deck) applyParagraphsRequests(objectID string, paragraphs []*Paragraph)
 		if startIndex <= endIndex {
 			endIndex++
 		}
-		styleReqs = append(stlyeReqs, &slides.Request{
+		styleReqs = append(styleReqs, &slides.Request{
 			CreateParagraphBullets: &slides.CreateParagraphBulletsRequest{
 				ObjectId:     objectID,
 				BulletPreset: convertBullet(r.bullet),

--- a/integration_apply_test.go
+++ b/integration_apply_test.go
@@ -22,6 +22,7 @@ func TestApply(t *testing.T) {
 		t.Fatal(err)
 	}
 	presentationID := d.ID()
+	t.Logf("Presentation URL for test: https://docs.google.com/presentation/d/%s", presentationID)
 	t.Cleanup(func() {
 		if err := Delete(ctx, presentationID); err != nil {
 			t.Fatalf("failed to delete presentation %s: %v", presentationID, err)
@@ -47,7 +48,7 @@ func TestApply(t *testing.T) {
 				t.Fatal(err)
 			}
 			if diff := cmp.Diff(before, tt.before, cmpopts...); diff != "" {
-				t.Error(diff)
+				t.Fatal(diff)
 			}
 
 			if err := d.Apply(ctx, tt.after); err != nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -118,7 +118,7 @@ func TestApplyMarkdown(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to compute distance between screenshots: %v", err)
 				}
-				if distance > 3 { // threshold for similarity
+				if distance > 1 { // threshold for similarity
 					diffpath := fmt.Sprintf("%s-%d.diff.png", tt.in, page)
 					_ = os.WriteFile(diffpath, got, 0600)
 					t.Errorf("screenshot %s does not match golden file %s: distance %d, see %s for diff", p, tt.in, distance, diffpath)


### PR DESCRIPTION
This pull request refactors the comparison logic for slides and related entities, improves test output clarity, and fixes minor typos in the codebase. The most notable changes include moving comparison helper functions into a new file, enhancing the similarity scoring mechanism, and refining test thresholds and error handling.

### Refactoring and Code Organization:

* Moved comparison helper functions (e.g., `slidesEqual`, `titlesEqual`, `paragraphsEqual`) from `action.go` to a new file, `compare.go`, to improve modularity and maintainability. Introduced a `Compare` method for the `Slide` struct to encapsulate comparison logic.

### Enhancements to Similarity Scoring:

* Updated `getSimilarity` in `action.go` to include block quote comparison, adding a scoring mechanism for block quotes to better evaluate slide similarity.

### Test Improvements:

* Added a log statement to `TestApply` in `integration_apply_test.go` to display the presentation URL for debugging purposes. Changed error handling to use `t.Fatal` instead of `t.Error` for more robust failure reporting. [[1]](diffhunk://#diff-f50ff63b42b5a6e50a4e76cd0d12ddde9d6d21168992afa675e696ccdb48e085R25) [[2]](diffhunk://#diff-f50ff63b42b5a6e50a4e76cd0d12ddde9d6d21168992afa675e696ccdb48e085L50-R51)
* Adjusted the similarity threshold in `TestApplyMarkdown` in `integration_test.go` from 3 to 1 for stricter screenshot comparison, ensuring higher accuracy in test validations.

### Minor Fixes:

* Corrected a typo in the variable name `stlyeReqs` to `styleReqs` in `deck.go`. [[1]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L1187-R1187) [[2]](diffhunk://#diff-a39d05a55b005ceac781a85bfa8273ab035f2f66d982b0988d768405fddac3c3L1274-R1276)