### PR TITLE
feat(compare): add sorting logic for BlockQuotes in blockQuotesEqual function

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -113,6 +113,41 @@ func blockQuotesEqual(bq1, bq2 []*BlockQuote) bool {
 	if len(bq1) != len(bq2) {
 		return false
 	}
+	slices.SortFunc(bq1, func(a *BlockQuote, b *BlockQuote) int {
+		if a.Nesting != b.Nesting {
+			return a.Nesting - b.Nesting
+		}
+		if len(a.Paragraphs) != len(b.Paragraphs) {
+			return len(a.Paragraphs) - len(b.Paragraphs)
+		}
+		jsonA, err := json.Marshal(a.Paragraphs)
+		if err != nil {
+			return -1 // Error case, treat as unequal
+		}
+		jsonB, err := json.Marshal(b.Paragraphs)
+		if err != nil {
+			return 1 // Error case, treat as unequal
+		}
+		return bytes.Compare(jsonA, jsonB)
+	})
+	slices.SortFunc(bq2, func(a *BlockQuote, b *BlockQuote) int {
+		if a.Nesting != b.Nesting {
+			return a.Nesting - b.Nesting
+		}
+		if len(a.Paragraphs) != len(b.Paragraphs) {
+			return len(a.Paragraphs) - len(b.Paragraphs)
+		}
+		jsonA, err := json.Marshal(a.Paragraphs)
+		if err != nil {
+			return -1 // Error case, treat as unequal
+		}
+		jsonB, err := json.Marshal(b.Paragraphs)
+		if err != nil {
+			return 1 // Error case, treat as unequal
+		}
+		return bytes.Compare(jsonA, jsonB)
+	})
+
 	for i := range bq1 {
 		if bq1[i] == nil || bq2[i] == nil {
 			if bq1[i] != bq2[i] {


### PR DESCRIPTION
This pull request introduces a change to the `blockQuotesEqual` function in `compare.go` to ensure consistent ordering of `BlockQuote` slices before comparison. Sorting is implemented using a custom function that considers nesting level, paragraph count, and serialized paragraph content.

Enhancements to `blockQuotesEqual`:

* [`compare.go`](diffhunk://#diff-815e74c236b005371c72430760405deade20fe85ba02c7c75026ed5de790ee2eR116-R150): Added sorting logic to the `blockQuotesEqual` function using `slices.SortFunc`. The sorting criteria include nesting level, the number of paragraphs, and serialized paragraph content, ensuring consistent order for comparison. Error cases during JSON serialization are handled by treating the elements as unequal.