### PR TITLE
fix(compare): ensure images are sorted without modifying input slices

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -96,14 +96,19 @@ func imagesEqual(images1, images2 []*Image) bool {
 	if len(images1) != len(images2) {
 		return false
 	}
-	slices.SortFunc(images1, func(a *Image, b *Image) int {
+	sorted1 := make([]*Image, len(images1))
+	copy(sorted1, images1)
+	sorted2 := make([]*Image, len(images2))
+	copy(sorted2, images2)
+
+	slices.SortFunc(sorted1, func(a *Image, b *Image) int {
 		return int(a.Checksum()) - int(b.Checksum())
 	})
-	slices.SortFunc(images2, func(a *Image, b *Image) int {
+	slices.SortFunc(sorted2, func(a *Image, b *Image) int {
 		return int(a.Checksum()) - int(b.Checksum())
 	})
-	for i, img := range images1 {
-		if !img.Compare(images2[i]) {
+	for i, img := range sorted1 {
+		if !img.Compare(sorted2[i]) {
 			return false
 		}
 	}


### PR DESCRIPTION
This pull request refactors the `imagesEqual` function in `compare.go` to ensure that the original slices of images remain unmodified during comparison by copying and sorting them into new slices before performing equality checks.

Refactoring for immutability:

* [`compare.go`](diffhunk://#diff-815e74c236b005371c72430760405deade20fe85ba02c7c75026ed5de790ee2eL99-R111): Updated the `imagesEqual` function to create copies of the input slices (`images1` and `images2`) before sorting them. This prevents unintended modifications to the original slices during the sorting process.