### PR TITLE
fix: add empty string check before copying image

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -925,7 +925,7 @@ func (d *Deck) updateLayout(ctx context.Context, index int, slide *Slide) (err e
 
 	for _, element := range currentSlide.PageElements {
 		// copy images from the current slide to the new slide
-		if element.Image != nil && element.Description != descriptionImageFromMarkdown {
+		if element.Image != nil && element.Description != descriptionImageFromMarkdown && element.Image.ContentUrl != "" {
 			req.Requests = append(req.Requests, &slides.Request{
 				CreateImage: &slides.CreateImageRequest{
 					ElementProperties: &slides.PageElementProperties{


### PR DESCRIPTION
It appears that the following fix in #285 was reverted.

https://github.com/k1LoW/deck/pull/285/commits/61979f21a3687930eab37a7a651771ddc58cdee3

In cases where placeholders or junk data remained on the page, or due to timing issues, the URL could become an empty string, and creating a request in such cases could result in an error. To prevent this, we added an empty string check.