### PR TITLE
pref: Efficiency and speed improvement of image upload to slides

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -129,7 +129,7 @@ func (d *Deck) ApplyPages(ctx context.Context, ss Slides, pages []int) (err erro
 	}
 	d.logger.Info("applying actions", slog.Any("actions", actionDetails))
 
-	// Pre-fetch current images in parallel for all slides that will be processed
+	// Pre-fetch current images in parallel for only the slides that will be updated
 	currentImages, err := d.preloadCurrentImages(ctx, actions)
 	if err != nil {
 		return fmt.Errorf("failed to preload current images: %w", err)

--- a/apply.go
+++ b/apply.go
@@ -127,7 +127,6 @@ func (d *Deck) ApplyPages(ctx context.Context, ss Slides, pages []int) (err erro
 			})
 		}
 	}
-	d.logger.Info("applying actions", slog.Any("actions", actionDetails))
 
 	// Pre-fetch current images in parallel for only the slides that will be updated
 	currentImages, err := d.preloadCurrentImages(ctx, actions)
@@ -149,6 +148,7 @@ func (d *Deck) ApplyPages(ctx context.Context, ss Slides, pages []int) (err erro
 		ClearAllUploadStateFromCache()
 	}()
 
+	d.logger.Info("applying actions", slog.Any("actions", actionDetails))
 	for _, action := range actions {
 		switch action.actionType {
 		case actionTypeAppend:

--- a/apply.go
+++ b/apply.go
@@ -152,7 +152,7 @@ func (d *Deck) ApplyPages(ctx context.Context, ss Slides, pages []int) (err erro
 	for _, action := range actions {
 		switch action.actionType {
 		case actionTypeAppend:
-			if err := d.AppendPage(ctx, action.slide, nil); err != nil {
+			if err := d.AppendPage(ctx, action.slide); err != nil {
 				return fmt.Errorf("failed to append slide: %w", err)
 			}
 		case actionTypeInsert:

--- a/apply.go
+++ b/apply.go
@@ -378,7 +378,7 @@ func (d *Deck) applyPage(ctx context.Context, index int, slide *Slide, preloaded
 		}
 
 		// Wait for image upload to complete
-		webContentLink, err := image.UploadInfo()
+		webContentLink, err := image.UploadInfo(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to upload image: %w", err)
 		}

--- a/apply.go
+++ b/apply.go
@@ -146,6 +146,7 @@ func (d *Deck) ApplyPages(ctx context.Context, ss Slides, pages []int) (err erro
 				d.logger.Error("failed to cleanup uploaded images", slog.Any("error", cleanupErr))
 			}
 		}
+		ClearAllUploadStateFromCache()
 	}()
 
 	for _, action := range actions {
@@ -384,7 +385,6 @@ func (d *Deck) applyPage(ctx context.Context, index int, slide *Slide, preloaded
 		if webContentLink == "" {
 			return fmt.Errorf("image not uploaded or webContentLink is empty")
 		}
-		// Cleanup will be done in batch at the end of ApplyPages
 		var imageObjectID string
 		if len(imagePlaceholders) > i {
 			imageObjectID = imagePlaceholders[i].objectID

--- a/apply.go
+++ b/apply.go
@@ -377,7 +377,7 @@ func (d *Deck) applyPage(ctx context.Context, index int, slide *Slide, preloaded
 		}
 
 		// Wait for image upload to complete
-		webContentLink, err := image.WaitForUpload()
+		webContentLink, err := image.UploadInfo()
 		if err != nil {
 			return fmt.Errorf("failed to upload image: %w", err)
 		}

--- a/cache.go
+++ b/cache.go
@@ -41,3 +41,11 @@ func StoreImageCache(key string, i *Image) {
 	}
 	globalCache.m[key] = i
 }
+
+func ClearAllUploadStateFromCache() {
+	globalCache.mu.Lock()
+	defer globalCache.mu.Unlock()
+	for _, v := range globalCache.m {
+		v.ClearUploadState()
+	}
+}

--- a/deck.go
+++ b/deck.go
@@ -256,7 +256,7 @@ func (d *Deck) DeletePageAfter(ctx context.Context, index int) (err error) {
 	return nil
 }
 
-func (d *Deck) AppendPage(ctx context.Context, slide *Slide, preloaded *currentImageData) (err error) {
+func (d *Deck) AppendPage(ctx context.Context, slide *Slide) (err error) {
 	defer func() {
 		err = errors.WithStack(err)
 	}()
@@ -268,7 +268,7 @@ func (d *Deck) AppendPage(ctx context.Context, slide *Slide, preloaded *currentI
 	if err := d.refresh(ctx); err != nil {
 		return fmt.Errorf("failed to refresh presentation: %w", err)
 	}
-	if err := d.applyPage(ctx, index, slide, preloaded); err != nil {
+	if err := d.applyPage(ctx, index, slide, nil); err != nil {
 		return fmt.Errorf("failed to apply page: %w", err)
 	}
 	if err := d.refresh(ctx); err != nil {

--- a/deck.go
+++ b/deck.go
@@ -256,7 +256,7 @@ func (d *Deck) DeletePageAfter(ctx context.Context, index int) (err error) {
 	return nil
 }
 
-func (d *Deck) AppendPage(ctx context.Context, slide *Slide) (err error) {
+func (d *Deck) AppendPage(ctx context.Context, slide *Slide, preloaded *currentImageData) (err error) {
 	defer func() {
 		err = errors.WithStack(err)
 	}()
@@ -268,7 +268,7 @@ func (d *Deck) AppendPage(ctx context.Context, slide *Slide) (err error) {
 	if err := d.refresh(ctx); err != nil {
 		return fmt.Errorf("failed to refresh presentation: %w", err)
 	}
-	if err := d.applyPage(ctx, index, slide); err != nil {
+	if err := d.applyPage(ctx, index, slide, preloaded); err != nil {
 		return fmt.Errorf("failed to apply page: %w", err)
 	}
 	if err := d.refresh(ctx); err != nil {
@@ -309,7 +309,7 @@ func (d *Deck) InsertPage(ctx context.Context, index int, slide *Slide) (err err
 	if err := d.refresh(ctx); err != nil {
 		return fmt.Errorf("failed to refresh presentation: %w", err)
 	}
-	if err := d.applyPage(ctx, index, slide); err != nil {
+	if err := d.applyPage(ctx, index, slide, nil); err != nil {
 		return fmt.Errorf("failed to apply page: %w", err)
 	}
 	if err := d.refresh(ctx); err != nil {

--- a/integration_action_test.go
+++ b/integration_action_test.go
@@ -40,7 +40,7 @@ func TestAction(t *testing.T) {
 					Layout:      "title-and-body",
 					Titles:      []string{"Slide 2"},
 					TitleBodies: toBodies([]string{"Slide 2"}),
-				}); err != nil {
+				}, nil); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -54,7 +54,7 @@ func TestAction(t *testing.T) {
 			before: Slides{},
 			actions: func(t *testing.T, d *Deck) {
 				if err := d.AppendPage(ctx, &Slide{Layout: "title-and-body",
-					Titles: []string{"Slide 1"}, TitleBodies: toBodies([]string{"Slide 1"})}); err != nil {
+					Titles: []string{"Slide 1"}, TitleBodies: toBodies([]string{"Slide 1"})}, nil); err != nil {
 
 					t.Fatal(err)
 				}

--- a/integration_action_test.go
+++ b/integration_action_test.go
@@ -40,7 +40,7 @@ func TestAction(t *testing.T) {
 					Layout:      "title-and-body",
 					Titles:      []string{"Slide 2"},
 					TitleBodies: toBodies([]string{"Slide 2"}),
-				}, nil); err != nil {
+				}); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -54,7 +54,7 @@ func TestAction(t *testing.T) {
 			before: Slides{},
 			actions: func(t *testing.T, d *Deck) {
 				if err := d.AppendPage(ctx, &Slide{Layout: "title-and-body",
-					Titles: []string{"Slide 1"}, TitleBodies: toBodies([]string{"Slide 1"})}, nil); err != nil {
+					Titles: []string{"Slide 1"}, TitleBodies: toBodies([]string{"Slide 1"})}); err != nil {
 
 					t.Fatal(err)
 				}

--- a/preload.go
+++ b/preload.go
@@ -72,6 +72,7 @@ func (d *Deck) preloadCurrentImages(ctx context.Context, actions []*action) (map
 	if len(imagesToPreload) == 0 {
 		return result, nil
 	}
+	d.logger.Info("preloading current images", slog.Int("count", len(imagesToPreload)))
 
 	// Process images in parallel
 	sem := semaphore.NewWeighted(maxPreloadWorkersNum)
@@ -138,6 +139,7 @@ func (d *Deck) preloadCurrentImages(ctx context.Context, actions []*action) (map
 		}
 	}
 
+	d.logger.Info("preloaded current images")
 	return result, nil
 }
 
@@ -181,6 +183,7 @@ func (d *Deck) startUploadingImages(
 		close(uploadedCh)
 		return uploadedCh
 	}
+	d.logger.Info("starting image upload", slog.Int("count", len(imagesToUpload)))
 
 	// Mark all images as upload in progress
 	for _, image := range imagesToUpload {

--- a/preload.go
+++ b/preload.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/api/drive/v3"
 )
 
-const maxPreloadWorkersNum = 8
+const maxPreloadWorkersNum = 4
 
 // currentImageData holds the result of parallel image fetching.
 type currentImageData struct {

--- a/preload.go
+++ b/preload.go
@@ -1,0 +1,152 @@
+package deck
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// currentImageData holds the result of parallel image fetching
+type currentImageData struct {
+	currentImages           []*Image
+	currentImageObjectIDMap map[*Image]string
+}
+
+// imageToPreload holds image information with slide context
+type imageToPreload struct {
+	slideIndex     int
+	imageIndex     int    // index within the slide
+	existingURL    string // URL of existing image
+	objectID       string // objectID of existing image
+	isFromMarkdown bool   // whether this image is from markdown
+}
+
+// imageResult holds the result of image processing
+type imageResult struct {
+	slideIndex int
+	imageIndex int
+	image      *Image
+	objectID   string
+}
+
+// preloadCurrentImages pre-fetches current images for all slides that will be processed
+func (d *Deck) preloadCurrentImages(ctx context.Context, actions []*action) (map[int]*currentImageData, error) {
+	result := make(map[int]*currentImageData)
+
+	// Collect all images that need preloading
+	var imagesToPreload []imageToPreload
+
+	for _, action := range actions {
+		switch action.actionType {
+		case actionTypeUpdate:
+			// Extract existing images from the current slide
+			if action.index < len(d.presentation.Slides) {
+				currentSlide := d.presentation.Slides[action.index]
+				imageIndexInSlide := 0
+				for _, element := range currentSlide.PageElements {
+					if element.Image != nil && element.Image.Placeholder == nil && element.Image.ContentUrl != "" {
+						imagesToPreload = append(imagesToPreload, imageToPreload{
+							slideIndex:     action.index,
+							imageIndex:     imageIndexInSlide,
+							existingURL:    element.Image.ContentUrl,
+							objectID:       element.ObjectId,
+							isFromMarkdown: element.Description == descriptionImageFromMarkdown,
+						})
+						imageIndexInSlide++
+					}
+				}
+			}
+		}
+	}
+
+	if len(imagesToPreload) == 0 {
+		return result, nil
+	}
+
+	// Process images in parallel
+	const maxWorkers = 8
+
+	imageCh := make(chan imageToPreload, len(imagesToPreload))
+	resultCh := make(chan imageResult, len(imagesToPreload))
+
+	// Start worker goroutines
+	g, ctx := errgroup.WithContext(ctx)
+	numWorkers := min(maxWorkers, len(imagesToPreload))
+
+	for range numWorkers {
+		g.Go(func() error {
+			for imgToPreload := range imageCh {
+				var image *Image
+				var err error
+
+				// Create Image from existing URL
+				if imgToPreload.isFromMarkdown {
+					image, err = NewImageFromMarkdown(imgToPreload.existingURL)
+				} else {
+					image, err = NewImage(imgToPreload.existingURL)
+				}
+				if err != nil {
+					return fmt.Errorf("failed to preload image from URL %s: %w", imgToPreload.existingURL, err)
+				}
+
+				select {
+				case resultCh <- imageResult{
+					slideIndex: imgToPreload.slideIndex,
+					imageIndex: imgToPreload.imageIndex,
+					image:      image,
+					objectID:   imgToPreload.objectID,
+				}:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			return nil
+		})
+	}
+
+	// Send work to workers
+	go func() {
+		defer close(imageCh)
+		for _, imgToPreload := range imagesToPreload {
+			imageCh <- imgToPreload
+		}
+	}()
+
+	// Close result channel when all workers are done
+	go func() {
+		g.Wait()
+		close(resultCh)
+	}()
+
+	// Collect results and build currentImageData directly with proper ordering
+	for res := range resultCh {
+		if res.image != nil {
+			if result[res.slideIndex] == nil {
+				result[res.slideIndex] = &currentImageData{
+					currentImages:           []*Image{},
+					currentImageObjectIDMap: map[*Image]string{},
+				}
+			}
+
+			// Resize currentImages slice if needed
+			if len(result[res.slideIndex].currentImages) <= res.imageIndex {
+				newSize := res.imageIndex + 1
+				newSlice := make([]*Image, newSize)
+				copy(newSlice, result[res.slideIndex].currentImages)
+				result[res.slideIndex].currentImages = newSlice
+			}
+
+			// Place image at the correct index
+			result[res.slideIndex].currentImages[res.imageIndex] = res.image
+			result[res.slideIndex].currentImageObjectIDMap[res.image] = res.objectID
+		}
+	}
+
+	// Wait for all workers to complete and check for errors
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("failed to preload images: %w", err)
+	}
+
+	return result, nil
+}

--- a/preload.go
+++ b/preload.go
@@ -14,6 +14,8 @@ import (
 	"google.golang.org/api/drive/v3"
 )
 
+const maxPreloadWorkersNum = 8
+
 // currentImageData holds the result of parallel image fetching.
 type currentImageData struct {
 	currentImages           []*Image
@@ -72,8 +74,7 @@ func (d *Deck) preloadCurrentImages(ctx context.Context, actions []*action) (map
 	}
 
 	// Process images in parallel
-	const maxWorkers = 8
-	sem := semaphore.NewWeighted(int64(maxWorkers))
+	sem := semaphore.NewWeighted(maxPreloadWorkersNum)
 	eg, ctx := errgroup.WithContext(ctx)
 	resultCh := make(chan imageResult, len(imagesToPreload))
 
@@ -189,8 +190,7 @@ func (d *Deck) startUploadingImages(
 	// Start uploading images asynchronously
 	go func() {
 		// Process images in parallel
-		const maxWorkers = 8
-		sem := semaphore.NewWeighted(int64(maxWorkers))
+		sem := semaphore.NewWeighted(maxPreloadWorkersNum)
 		eg, ctx := errgroup.WithContext(ctx)
 
 		for _, image := range imagesToUpload {
@@ -273,8 +273,7 @@ func (d *Deck) startUploadingImages(
 
 // cleanupUploadedImages deletes uploaded images in parallel.
 func (d *Deck) cleanupUploadedImages(ctx context.Context, uploadedCh <-chan uploadedImageInfo) error {
-	const maxWorkers = 8
-	sem := semaphore.NewWeighted(int64(maxWorkers))
+	sem := semaphore.NewWeighted(maxPreloadWorkersNum)
 	var wg sync.WaitGroup
 
 	for {

--- a/slide.go
+++ b/slide.go
@@ -377,24 +377,23 @@ func (i *Image) SetUploadResult(webContentLink, uploadedID string, err error) {
 	}
 }
 
-// WaitForUpload waits for the upload to complete and returns the result
-func (i *Image) WaitForUpload() (webContentLink, uploadedID string, err error) {
+// WaitForUpload waits for the upload to complete and returns the webContentLink
+func (i *Image) WaitForUpload() (string, error) {
 	for {
 		i.uploadMutex.RLock()
 		state := i.uploadState
 		link := i.webContentLink
-		id := i.uploadedID
 		uploadErr := i.uploadError
 		i.uploadMutex.RUnlock()
 
 		switch state {
 		case uploadStateNotStarted:
-			// Image upload not started, return empty values
-			return "", "", nil
+			// Image upload not started, return empty value
+			return "", nil
 		case uploadStateCompleted:
-			return link, id, nil
+			return link, nil
 		case uploadStateFailed:
-			return "", "", uploadErr
+			return "", uploadErr
 		case uploadStateInProgress:
 			// Continue waiting
 			time.Sleep(10 * time.Millisecond)

--- a/slide.go
+++ b/slide.go
@@ -355,14 +355,14 @@ func (i *Image) UnmarshalJSON(data []byte) (err error) {
 	return nil
 }
 
-// StartUpload marks the image as upload in progress
+// StartUpload marks the image as upload in progress.
 func (i *Image) StartUpload() {
 	i.uploadMutex.Lock()
 	defer i.uploadMutex.Unlock()
 	i.uploadState = uploadStateInProgress
 }
 
-// SetUploadResult sets the upload result (success or failure)
+// SetUploadResult sets the upload result (success or failure).
 func (i *Image) SetUploadResult(webContentLink, uploadedID string, err error) {
 	i.uploadMutex.Lock()
 	defer i.uploadMutex.Unlock()
@@ -377,7 +377,7 @@ func (i *Image) SetUploadResult(webContentLink, uploadedID string, err error) {
 	}
 }
 
-// WaitForUpload waits for the upload to complete and returns the webContentLink
+// WaitForUpload waits for the upload to complete and returns the webContentLink.
 func (i *Image) WaitForUpload() (string, error) {
 	for {
 		i.uploadMutex.RLock()
@@ -401,7 +401,7 @@ func (i *Image) WaitForUpload() (string, error) {
 	}
 }
 
-// IsUploadNeeded returns true if the image needs to be uploaded
+// IsUploadNeeded returns true if the image needs to be uploaded.
 func (i *Image) IsUploadNeeded() bool {
 	i.uploadMutex.RLock()
 	defer i.uploadMutex.RUnlock()

--- a/slide.go
+++ b/slide.go
@@ -377,8 +377,8 @@ func (i *Image) SetUploadResult(webContentLink, uploadedID string, err error) {
 	}
 }
 
-// WaitForUpload waits for the upload to complete and returns the webContentLink.
-func (i *Image) WaitForUpload() (string, error) {
+// UploadInfo waits for the upload to complete and returns the webContentLink.
+func (i *Image) UploadInfo() (string, error) {
 	for {
 		i.uploadMutex.RLock()
 		state := i.uploadState

--- a/slide.go
+++ b/slide.go
@@ -405,3 +405,11 @@ func (i *Image) IsUploadNeeded() bool {
 	defer i.uploadMutex.RUnlock()
 	return i.uploadState == uploadStateNotStarted
 }
+
+func (i *Image) ClearUploadState() {
+	i.uploadMutex.Lock()
+	defer i.uploadMutex.Unlock()
+	i.uploadState = uploadStateNotStarted
+	i.webContentLink = ""
+	i.uploadError = nil
+}

--- a/slide.go
+++ b/slide.go
@@ -100,7 +100,6 @@ type Image struct {
 	uploadMutex    sync.RWMutex
 	uploadState    uploadState
 	webContentLink string
-	uploadedID     string
 	uploadError    error
 }
 
@@ -372,7 +371,6 @@ func (i *Image) SetUploadResult(webContentLink, uploadedID string, err error) {
 	} else {
 		i.uploadState = uploadStateCompleted
 		i.webContentLink = webContentLink
-		i.uploadedID = uploadedID
 		i.uploadError = nil
 	}
 }


### PR DESCRIPTION
This PR improves image upload processing performance by implementing parallel image preloading, asynchronous uploads, and batch cleanup operations. The changes reduce bottlenecks in slide generation.

There are other optimization plans, but for now, I've only included this one in the pull request. It's a big change, so it may be difficult to review, but I appreciate your cooperation.
## Background
Currently, existing image fetching within the slide, uploading to Google Drive, and deletion are executed sequentially for each slide, which is inefficient.

## Changes
With this change, before updating the slides, the images contained in the slides to be updated are first retrieved in parallel. Then, the new images are uploaded to Google Drive asynchronously, also in parallel.

Finally, after all processing is complete, we will delete the images in parallel.

Parallelism is also limited to 4, so there is no problem with excessive requests.

## Functionality check
I'm confirmed that every testing works, including integration.

In addition to simple applying, I've also checked the behavior of applying differences while watching.

## Benchmark

I saw a significant difference in my 130-page document with 20 images (including code blocks). The performance will likely improve further for slides with more images.

About 15% faster than before.
### current
- `deck apply -v -c 'silicon -l {{lang}} -o {{output}}' index.md  10.50s user 1.87s system 3% cpu 5:44.63 total`
- `deck apply -v -c 'silicon -l {{lang}} -o {{output}}' index.md  11.34s user 2.19s system 4% cpu 5:32.58 total`
- `deck apply -v -c 'silicon -l {{lang}} -o {{output}}' index.md  10.59s user 2.17s system 3% cpu 5:24.39 total`
- `deck apply -v -c 'silicon -l {{lang}} -o {{output}}' index.md  10.91s user 2.18s system 3% cpu 5:44.46 total`

### updated
- `./deck apply -v -c 'silicon -l {{lang}} -o {{output}}' index.md 11.03s user 1.97s system 4% cpu 4:59.93 total`
- `./deck apply -v -c 'silicon -l {{lang}} -o {{output}}' index.md 11.95s user 2.08s system 4% cpu 4:41.20 total`
- `./deck apply -v -c 'silicon -l {{lang}} -o {{output}}' index.md 11.04s user 2.31s system 4% cpu 4:54.49 total`
- `./deck apply -v -c 'silicon -l {{lang}} -o {{output}}' index.md 11.17s user 2.04s system 4% cpu 4:37.50 total`
