### PR TITLE
feat: add 'open' subcommand to open Google Slides in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ This is useful during the content creation process as it allows you to see your 
 > [!NOTE]
 > The `--watch` flag cannot be used together with the `--page` flag.
 
+### Open presentation in browser
+
+You can quickly open your Google Slides presentation in your default web browser:
+
+```console
+$ deck open deck.md
+```
+
 ## Support markdown rules
 
 ### YAML Frontmatter

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/k1LoW/deck"
+	"github.com/k1LoW/deck/md"
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+)
+
+var openPresentationID string
+
+var openCmd = &cobra.Command{
+	Use:   "open [DECK_FILE]",
+	Short: "open Google Slides presentation in browser",
+	Long:  `open Google Slides presentation in browser.`,
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var presentationID string
+
+		if len(args) == 1 {
+			f := args[0]
+			markdownData, err := md.ParseFile(f)
+			if err != nil {
+				return err
+			}
+			if markdownData.Frontmatter != nil && markdownData.Frontmatter.PresentationID != "" {
+				presentationID = markdownData.Frontmatter.PresentationID
+			}
+		}
+		// Command line flag takes precedence
+		if openPresentationID != "" {
+			presentationID = openPresentationID
+		}
+
+		if presentationID == "" {
+			return fmt.Errorf("presentation ID is required. Use --presentation-id or set it in the frontmatter of the markdown file")
+		}
+
+		url := deck.PresentationIDtoURL(presentationID)
+		cmd.Println(url)
+		return browser.OpenURL(url)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(openCmd)
+	openCmd.Flags().StringVarP(&openPresentationID, "presentation-id", "p", "", "Google Slides presentation ID")
+}

--- a/list.go
+++ b/list.go
@@ -62,8 +62,14 @@ func (d *Deck) ListLayouts() []string {
 // ListSlideURLs lists URLs of the slides in the Google Slides presentation.
 func (d *Deck) ListSlideURLs() []string {
 	var slideURLs []string
+	baseURL := PresentationIDtoURL(d.id)
 	for _, s := range d.presentation.Slides {
-		slideURLs = append(slideURLs, fmt.Sprintf("https://docs.google.com/presentation/d/%s/present?slide=id.%s", d.id, s.ObjectId))
+		slideURLs = append(slideURLs, baseURL+"present?slide=id."+s.ObjectId)
 	}
 	return slideURLs
+}
+
+// PresentationIDtoURL converts a presentation ID to a Google Slides URL.
+func PresentationIDtoURL(presentationID string) string {
+	return fmt.Sprintf("https://docs.google.com/presentation/d/%s/", presentationID)
 }


### PR DESCRIPTION
Add a new 'deck open' subcommand that opens the Google Slides presentation directly in the web browser. This improves the workflow by allowing users to quickly access their presentations without manually constructing URLs.

Usage:
- deck open deck.md - Opens presentation using ID from frontmatter

The command uses the system's default browser to open the presentation.