### PR TITLE
perf: Batch delete pages

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -920,10 +920,8 @@ func (d *Deck) updateLayout(ctx context.Context, index int, slide *Slide) (err e
 	req := &slides.BatchUpdatePresentationRequest{
 		Requests: []*slides.Request{},
 	}
-	insertReq := &slides.BatchUpdatePresentationRequest{
-		Requests: []*slides.Request{},
-	}
 	var (
+		insertReqs []*slides.Request
 		styleReqs  []*slides.Request
 		bulletReqs []*slides.Request
 	)
@@ -1032,7 +1030,7 @@ func (d *Deck) updateLayout(ctx context.Context, index int, slide *Slide) (err e
 				},
 			})
 
-			insertReq.Requests = append(insertReq.Requests, &slides.Request{
+			insertReqs = append(insertReqs, &slides.Request{
 				InsertText: &slides.InsertTextRequest{
 					ObjectId: shapeObjectID,
 					Text:     strings.TrimSuffix(text, "\n"),
@@ -1090,22 +1088,17 @@ func (d *Deck) updateLayout(ctx context.Context, index int, slide *Slide) (err e
 
 			if len(styleReqs) > 0 || len(bulletReqs) > 0 {
 				// Apply styles first, then bullets (important for correct rendering)
-				insertReq.Requests = append(insertReq.Requests, styleReqs...)
-				insertReq.Requests = append(insertReq.Requests, bulletReqs...)
+				insertReqs = append(insertReqs, styleReqs...)
+				insertReqs = append(insertReqs, bulletReqs...)
 				styleReqs = nil  // reset after adding to requests
 				bulletReqs = nil // reset after adding to requests
 			}
 		}
 	}
-
+	req.Requests = append(req.Requests, insertReqs...)
 	if len(req.Requests) > 0 {
 		if _, err := d.srv.Presentations.BatchUpdate(d.id, req).Context(ctx).Do(); err != nil {
-			return fmt.Errorf("failed to copy images: %w", err)
-		}
-	}
-	if len(insertReq.Requests) > 0 {
-		if _, err := d.srv.Presentations.BatchUpdate(d.id, insertReq).Context(ctx).Do(); err != nil {
-			return fmt.Errorf("failed to insert text: %w", err)
+			return fmt.Errorf("failed to copy images or insert text: %w", err)
 		}
 	}
 

--- a/apply.go
+++ b/apply.go
@@ -1111,7 +1111,7 @@ func (d *Deck) updateLayout(ctx context.Context, index int, slide *Slide) (err e
 		}
 	}
 
-	if err := d.DeletePage(ctx, index); err != nil {
+	if err := d.DeletePages(ctx, []int{index}); err != nil {
 		return err
 	}
 	return nil

--- a/deck.go
+++ b/deck.go
@@ -244,18 +244,6 @@ func (d *Deck) Export(ctx context.Context, w io.Writer) (err error) {
 	return nil
 }
 
-func (d *Deck) DeletePage(ctx context.Context, index int) (err error) {
-	defer func() {
-		err = errors.WithStack(err)
-	}()
-	d.logger.Info("deleting page", slog.Int("index", index))
-	if err := d.deletePage(ctx, index); err != nil {
-		return err
-	}
-	d.logger.Info("deleted page", slog.Int("index", index))
-	return nil
-}
-
 func (d *Deck) DeletePages(ctx context.Context, indices []int) (err error) {
 	defer func() {
 		err = errors.WithStack(err)
@@ -284,7 +272,7 @@ func (d *Deck) DeletePages(ctx context.Context, indices []int) (err error) {
 		if err := d.refresh(ctx); err != nil {
 			return fmt.Errorf("failed to refresh presentation after delete pages: %w", err)
 		}
-		d.logger.Info("deleted pages", slog.Any("indices", indices))
+		d.logger.Info("deleted pages", slog.Int("count", len(reqs)), slog.Any("indices", indices))
 	}
 	return nil
 }
@@ -501,32 +489,6 @@ func (d *Deck) createPage(ctx context.Context, index int, slide *Slide) (err err
 		return err
 	}
 
-	return nil
-}
-
-func (d *Deck) deletePage(ctx context.Context, index int) (err error) {
-	defer func() {
-		err = errors.WithStack(err)
-	}()
-	if len(d.presentation.Slides) <= index {
-		return nil
-	}
-	currentSlide := d.presentation.Slides[index]
-	req := &slides.BatchUpdatePresentationRequest{
-		Requests: []*slides.Request{
-			{
-				DeleteObject: &slides.DeleteObjectRequest{
-					ObjectId: currentSlide.ObjectId,
-				},
-			},
-		},
-	}
-	if _, err := d.srv.Presentations.BatchUpdate(d.id, req).Context(ctx).Do(); err != nil {
-		return err
-	}
-	if err := d.refresh(ctx); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/integration_action_test.go
+++ b/integration_action_test.go
@@ -172,7 +172,7 @@ func TestAction(t *testing.T) {
 			if err := d.DeletePageAfter(ctx, 0); err != nil {
 				t.Fatal(err)
 			}
-			if err := d.DeletePage(ctx, 0); err != nil {
+			if err := d.DeletePages(ctx, []int{0}); err != nil {
 				t.Fatal(err)
 			}
 			if err := d.Apply(ctx, tt.before); err != nil {

--- a/logger/dot/dot.go
+++ b/logger/dot/dot.go
@@ -74,11 +74,17 @@ func (h *dotHandler) Handle(ctx context.Context, r slog.Record) (err error) {
 		}
 		return nil
 	}
-	if r.Message == "deleted page" {
-		if err := h.write([]byte(gray("-"))); err != nil {
-			return err
-		}
-		return nil
+	if r.Message == "deleted pages" {
+		var count int
+		r.Attrs(func(attr slog.Attr) bool {
+			if attr.Key == "count" {
+				count = int(attr.Value.Int64())
+				return false
+			}
+			return true
+		})
+		msg := strings.Repeat("-", count)
+		return h.write([]byte(gray(msg)))
 	}
 	if r.Message == "appended page" {
 		if err := h.write([]byte(yellow("+"))); err != nil {


### PR DESCRIPTION
Currently, a request is issued and refreshed for each page deletion. However, since consecutive deletion requests can be sent as a single request, we have consolidated them.

Furthermore, Deck.DeletePage has been consolidated into the newly created DeletePages.

This should make the behavior of `--watch` more comfortable.