### PR TITLE
perf: Apply slides in bulk

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -316,8 +316,15 @@ func (d *Deck) AppendPage(ctx context.Context, slide *Slide) (err error) {
 	if err := d.refresh(ctx); err != nil {
 		return fmt.Errorf("failed to refresh presentation: %w", err)
 	}
-	if err := d.applyPage(ctx, index, slide, nil); err != nil {
+	if reqs, err := d.prepareToApplyPage(ctx, index, slide, nil); err != nil {
 		return fmt.Errorf("failed to apply page: %w", err)
+	} else if len(reqs) > 0 {
+		req := &slides.BatchUpdatePresentationRequest{
+			Requests: reqs,
+		}
+		if _, err := d.srv.Presentations.BatchUpdate(d.id, req).Context(ctx).Do(); err != nil {
+			return err
+		}
 	}
 	if err := d.refresh(ctx); err != nil {
 		return fmt.Errorf("failed to refresh presentation: %w", err)
@@ -357,8 +364,15 @@ func (d *Deck) InsertPage(ctx context.Context, index int, slide *Slide) (err err
 	if err := d.refresh(ctx); err != nil {
 		return fmt.Errorf("failed to refresh presentation: %w", err)
 	}
-	if err := d.applyPage(ctx, index, slide, nil); err != nil {
+	if reqs, err := d.prepareToApplyPage(ctx, index, slide, nil); err != nil {
 		return fmt.Errorf("failed to apply page: %w", err)
+	} else if len(reqs) > 0 {
+		req := &slides.BatchUpdatePresentationRequest{
+			Requests: reqs,
+		}
+		if _, err := d.srv.Presentations.BatchUpdate(d.id, req).Context(ctx).Do(); err != nil {
+			return err
+		}
 	}
 	if err := d.refresh(ctx); err != nil {
 		return fmt.Errorf("failed to refresh presentation: %w", err)


### PR DESCRIPTION
With the changes up to #310, it is now possible to apply slides in bulk. I implemented this and it works fine.

This means that generating my 130 slides can now be done in under 30 seconds. In the current version, this takes over 150 seconds, and just a month ago, it took over 750 seconds.

This is a significant improvement. This was made possible by the excellent action execution order logic of the original generateActions. Thank you.