### PR TITLE
feat: adjust imageReplaceMethod for code blocks

### DIFF
--- a/action.go
+++ b/action.go
@@ -510,6 +510,7 @@ func copySlide(slide *Slide) *Slide {
 		for _, copiedImage := range copied.Images {
 			if image.Compare(copiedImage) {
 				copiedImage.fromMarkdown = image.fromMarkdown
+				copiedImage.codeBlock = image.codeBlock
 				copiedImage.modTime = image.modTime
 			}
 		}
@@ -544,6 +545,7 @@ func copySlides(slides Slides) (_ Slides, err error) {
 			for _, copiedImage := range copied[i].Images {
 				if image.Compare(copiedImage) {
 					copiedImage.fromMarkdown = image.fromMarkdown
+					copiedImage.codeBlock = image.codeBlock
 					copiedImage.modTime = image.modTime
 				}
 			}

--- a/apply.go
+++ b/apply.go
@@ -464,7 +464,7 @@ func (d *Deck) prepareToApplyPage(ctx context.Context, index int, slide *Slide, 
 		}
 
 		// Wait for image upload to complete
-		info, err := image.uploadInfo(ctx)
+		info, err := image.UploadInfo(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to upload image: %w", err)
 		}

--- a/md/md.go
+++ b/md/md.go
@@ -606,7 +606,7 @@ func genCodeImage(ctx context.Context, codeBlockToImageCmd string, codeBlock *Co
 	if err != nil {
 		b = stdout.Bytes() // use stdout if output file is not found
 	}
-	return deck.NewImageFromMarkdownBuffer(bytes.NewBuffer(b))
+	return deck.NewImageFromCodeBlock(bytes.NewBuffer(b))
 }
 
 type fragment struct {

--- a/slide.go
+++ b/slide.go
@@ -452,8 +452,8 @@ type uploadInfo struct {
 	codeBlock bool
 }
 
-// uploadInfo waits for the upload to complete and returns the webContentLink.
-func (i *Image) uploadInfo(ctx context.Context) (*uploadInfo, error) {
+// UploadInfo waits for the upload to complete and returns the webContentLink.
+func (i *Image) UploadInfo(ctx context.Context) (*uploadInfo, error) {
 	for {
 		i.uploadMutex.RLock()
 		state := i.uploadState

--- a/slide.go
+++ b/slide.go
@@ -96,6 +96,7 @@ type Image struct {
 	checksum     uint32                 // Checksum for the image data
 	pHash        *goimagehash.ImageHash // Perceptual hash for JPEG images
 	modTime      time.Time              // Modification time of the image file, if applicable
+	codeBlock    bool                   // Whether the image was created from a code block
 
 	// Upload state management
 	uploadMutex    sync.RWMutex
@@ -255,7 +256,7 @@ func NewImageFromMarkdown(pathOrURL string) (_ *Image, err error) {
 	return i, nil
 }
 
-func NewImageFromMarkdownBuffer(r io.Reader) (_ *Image, err error) {
+func NewImageFromCodeBlock(r io.Reader) (_ *Image, err error) {
 	defer func() {
 		err = errors.WithStack(err)
 	}()
@@ -264,6 +265,7 @@ func NewImageFromMarkdownBuffer(r io.Reader) (_ *Image, err error) {
 		return nil, fmt.Errorf("failed to create image from code block: %w", err)
 	}
 	i.fromMarkdown = true
+	i.codeBlock = true
 	return i, nil
 }
 
@@ -445,8 +447,13 @@ func (i *Image) SetUploadResult(webContentLink, uploadedID string, err error) {
 	}
 }
 
-// UploadInfo waits for the upload to complete and returns the webContentLink.
-func (i *Image) UploadInfo(ctx context.Context) (string, error) {
+type uploadInfo struct {
+	url       string
+	codeBlock bool
+}
+
+// uploadInfo waits for the upload to complete and returns the webContentLink.
+func (i *Image) uploadInfo(ctx context.Context) (*uploadInfo, error) {
 	for {
 		i.uploadMutex.RLock()
 		state := i.uploadState
@@ -457,15 +464,18 @@ func (i *Image) UploadInfo(ctx context.Context) (string, error) {
 		switch state {
 		case uploadStateNotStarted:
 			// Image upload not started, return empty value
-			return "", nil
+			return nil, nil
 		case uploadStateCompleted:
-			return link, nil
+			return &uploadInfo{
+				url:       link,
+				codeBlock: i.codeBlock,
+			}, nil
 		case uploadStateFailed:
-			return "", uploadErr
+			return nil, uploadErr
 		case uploadStateInProgress:
 			select {
 			case <-ctx.Done():
-				return "", ctx.Err()
+				return nil, ctx.Err()
 			case <-time.After(10 * time.Millisecond):
 				// Continue waiting
 			}


### PR DESCRIPTION
In code blocks, the aspect ratio and size are undefined, and it is important to display the entire image generated, so I would like to modify the image replacement method.