### PR TITLE
refactoring: compare.go

### DIFF
--- a/action.go
+++ b/action.go
@@ -568,11 +568,11 @@ func getSimilarity(beforeSlide, afterSlide *Slide) int {
 	if beforeSlide.Layout == afterSlide.Layout && beforeSlide.Layout != "" {
 		score += 50 // Increased layout base score from 10 to 50
 
-		if len(beforeSlide.Titles) > 0 && len(afterSlide.Titles) > 0 && titlesEqual(beforeSlide.Titles, afterSlide.Titles) {
+		if len(beforeSlide.Titles) > 0 && slices.Equal(beforeSlide.Titles, afterSlide.Titles) {
 			score += 80
 		}
 
-		if len(beforeSlide.Subtitles) > 0 && len(afterSlide.Subtitles) > 0 && subtitlesEqual(beforeSlide.Subtitles, afterSlide.Subtitles) {
+		if len(beforeSlide.Subtitles) > 0 && slices.Equal(beforeSlide.Subtitles, afterSlide.Subtitles) {
 			score += 20
 		}
 

--- a/action.go
+++ b/action.go
@@ -558,7 +558,7 @@ func getSimilarity(beforeSlide, afterSlide *Slide) int {
 		return 0
 	}
 
-	if slidesEqual(beforeSlide, afterSlide) {
+	if beforeSlide.Equal(afterSlide) {
 		return 500
 	}
 

--- a/action.go
+++ b/action.go
@@ -508,7 +508,7 @@ func copySlide(slide *Slide) *Slide {
 			continue
 		}
 		for _, copiedImage := range copied.Images {
-			if image.Compare(copiedImage) {
+			if image.Equivalent(copiedImage) {
 				copiedImage.fromMarkdown = image.fromMarkdown
 				copiedImage.modTime = image.modTime
 			}
@@ -542,7 +542,7 @@ func copySlides(slides Slides) (_ Slides, err error) {
 	for i, slide := range slides {
 		for _, image := range slide.Images {
 			for _, copiedImage := range copied[i].Images {
-				if image.Compare(copiedImage) {
+				if image.Equivalent(copiedImage) {
 					copiedImage.fromMarkdown = image.fromMarkdown
 					copiedImage.modTime = image.modTime
 				}

--- a/action_test.go
+++ b/action_test.go
@@ -1667,7 +1667,7 @@ func TestGenerateActionsWithImages(t *testing.T) {
 			for i, slide := range got {
 				for _, image := range slide.Images {
 					found := slices.ContainsFunc(tt.after[i].Images, func(afterImage *Image) bool {
-						return image.Compare(afterImage)
+						return image.Equivalent(afterImage)
 					})
 					if !found {
 						t.Errorf("image not found in slide %d", i+1)

--- a/apply.go
+++ b/apply.go
@@ -514,7 +514,7 @@ func (d *Deck) prepareToApplyPage(ctx context.Context, index int, slide *Slide, 
 	// set text boxes
 	for i, bq := range slide.BlockQuotes {
 		found := slices.ContainsFunc(currentTextBoxes, func(currentTextBox *textBox) bool {
-			return paragraphsEqual(currentTextBox.paragraphs, bq.Paragraphs)
+			return slices.EqualFunc(currentTextBox.paragraphs, bq.Paragraphs, paragraphEqual)
 		})
 		if found {
 			continue
@@ -622,7 +622,7 @@ func (d *Deck) prepareToApplyPage(ctx context.Context, index int, slide *Slide, 
 			continue
 		}
 		found := slices.ContainsFunc(slide.BlockQuotes, func(bq *BlockQuote) bool {
-			return paragraphsEqual(currentTextBox.paragraphs, bq.Paragraphs)
+			return slices.EqualFunc(currentTextBox.paragraphs, bq.Paragraphs, paragraphEqual)
 		})
 		if found {
 			continue

--- a/apply.go
+++ b/apply.go
@@ -457,7 +457,7 @@ func (d *Deck) prepareToApplyPage(ctx context.Context, index int, slide *Slide, 
 	})
 	for i, image := range slide.Images {
 		found := slices.ContainsFunc(currentImages, func(currentImage *Image) bool {
-			return currentImage.Compare(image)
+			return currentImage.Equivalent(image)
 		})
 		if found {
 			continue
@@ -600,7 +600,7 @@ func (d *Deck) prepareToApplyPage(ctx context.Context, index int, slide *Slide, 
 			continue
 		}
 		found := slices.ContainsFunc(slide.Images, func(image *Image) bool {
-			return currentImage.Compare(image)
+			return currentImage.Equivalent(image)
 		})
 		if found {
 			continue

--- a/compare.go
+++ b/compare.go
@@ -108,7 +108,7 @@ func imagesEqual(images1, images2 []*Image) bool {
 		return int(a.Checksum()) - int(b.Checksum())
 	})
 	for i, img := range sorted1 {
-		if !img.Compare(sorted2[i]) {
+		if !img.Equivalent(sorted2[i]) {
 			return false
 		}
 	}

--- a/compare.go
+++ b/compare.go
@@ -7,19 +7,13 @@ import (
 	"strings"
 )
 
-func (s Slides) Compare(other Slides) bool { //nostyle:recvtype
-	if len(s) != len(other) {
-		return false
-	}
-	for i := range s {
-		if !slidesEqual(s[i], other[i]) {
-			return false
-		}
-	}
-	return true
+func (s Slides) Equal(other Slides) bool { //nostyle:recvtype
+	return slices.EqualFunc(s, other, func(a, b *Slide) bool {
+		return a.Equal(b)
+	})
 }
 
-func (s *Slide) Compare(other *Slide) bool {
+func (s *Slide) Equal(other *Slide) bool {
 	if s == nil || other == nil {
 		return s == other
 	}
@@ -45,10 +39,6 @@ func (s *Slide) Compare(other *Slide) bool {
 		return false
 	}
 	return true
-}
-
-func slidesEqual(slide1, slide2 *Slide) bool {
-	return slide1.Compare(slide2)
 }
 
 func titlesEqual(titles1, titles2 []string) bool {

--- a/integration_test.go
+++ b/integration_test.go
@@ -222,7 +222,7 @@ func TestRoundTripSlidesToGoogleSlidesPresentationAndBack(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !base.Compare(applied) {
+			if !base.Equal(applied) {
 				diff := cmp.Diff(base, applied, cmpopts...)
 				t.Errorf("slides after apply do not match base: %s", diff)
 			}
@@ -233,7 +233,7 @@ func TestRoundTripSlidesToGoogleSlidesPresentationAndBack(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !applied.Compare(applied2) {
+			if !applied.Equal(applied2) {
 				diff := cmp.Diff(applied, applied2, cmpopts...)
 				t.Errorf("slides after apply do not match base: %s", diff)
 			}

--- a/preload.go
+++ b/preload.go
@@ -167,7 +167,7 @@ func (d *Deck) startUploadingImages(
 				var found bool
 				if currentImagesForSlide, exists := currentImages[action.index]; exists {
 					found = slices.ContainsFunc(currentImagesForSlide.currentImages, func(currentImage *Image) bool {
-						return currentImage.Compare(image)
+						return currentImage.Equivalent(image)
 					})
 				}
 				if !found && image.IsUploadNeeded() {

--- a/slide.go
+++ b/slide.go
@@ -296,7 +296,7 @@ func newImageFromBuffer(r io.Reader) (_ *Image, err error) {
 	}, nil
 }
 
-func (i *Image) Compare(ii *Image) bool {
+func (i *Image) Equivalent(ii *Image) bool {
 	if i == nil || ii == nil {
 		return false
 	}

--- a/slide_test.go
+++ b/slide_test.go
@@ -235,7 +235,7 @@ func TestImageBytes(t *testing.T) {
 	}
 }
 
-func TestCompare(t *testing.T) {
+func TestEquivalent(t *testing.T) {
 	tests := []struct {
 		name     string
 		imageA   string
@@ -282,7 +282,7 @@ func TestCompare(t *testing.T) {
 
 			result := imgA.Equivalent(imgB)
 			if result != tt.expected {
-				t.Errorf("Compare() = %v, expected %v", result, tt.expected)
+				t.Errorf("Equivalent() = %v, expected %v", result, tt.expected)
 			}
 		})
 	}

--- a/slide_test.go
+++ b/slide_test.go
@@ -280,7 +280,7 @@ func TestCompare(t *testing.T) {
 				t.Fatalf("failed to load image B: %v", err)
 			}
 
-			result := imgA.Compare(imgB)
+			result := imgA.Equivalent(imgB)
 			if result != tt.expected {
 				t.Errorf("Compare() = %v, expected %v", result, tt.expected)
 			}


### PR DESCRIPTION
It is unclear under what conditions `Compare(a, b) bool` returns true, and it is common for Compare(a, b) int` to take three values, like the spaceship operator (`<=>`).

I renamed the `Compare` method and used the `slices` package to remove unnecessary functions and simplify the code.