### PR TITLE
feat: add support for code block to image conversion command in frontmatter or config

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The frontmatter must be:
 - `presentationID` (string): Google Slides presentation ID. When specified, you can use the simplified command syntax.
 - `title` (string): title of the presentation. When specified, you can use the simplified command syntax.
 - `breaks` (boolean): Control how line breaks are rendered. Default (`false` or omitted) renders line breaks as spaces. When `true`, line breaks in markdown are rendered as actual line breaks in slides. Can also be configured globally in `config.yml`.
+- `codeBlockToImageCommand` (string): Command to convert code blocks to images. When specified, code blocks in the presentation will be converted to images using this command. Can also be configured globally in `config.yml`.
 - `defaults` (array): Define conditional actions using CEL (Common Expression Language) expressions. Actions are automatically applied to pages based on page structure and content. Only applies to pages without explicit page configuration. Can also be configured globally in `config.yml`.
 
 #### Configuration File
@@ -158,6 +159,7 @@ The configuration file uses YAML format and supports the same fields as frontmat
 ```yaml
 # Global configuration for deck
 breaks: true
+codeBlockToImageCommand: "go run testdata/txt2img/main.go"
 
 defaults:
   # First page should always use title layout
@@ -177,6 +179,7 @@ defaults:
 ##### Available configuration fields
 
 - **`breaks`** (boolean): Global line break rendering behavior
+- **`codeBlockToImageCommand`** (string): Global command to convert code blocks to images
 - **`defaults`** (array): Global default conditions and actions using CEL expressions
 
 ##### Configuration precedence
@@ -360,6 +363,26 @@ By using the `--code-block-to-image-command (-c)` option, you can convert [Markd
 $ deck apply --code-block-to-image-command "some-command" -i xxxxxXXXXxxxxxXXXXxxxxxxxxxx deck.md
 ```
 
+Alternatively, you can set the command globally in your configuration file or per-presentation in the frontmatter:
+
+**Configuration file example:**
+```yaml
+# config.yml
+codeBlockToImageCommand: "some-command"
+```
+
+**Frontmatter example:**
+```yaml
+---
+codeBlockToImageCommand: "some-sommand"
+---
+```
+
+When both are specified, the priority order is:
+1. Command-line option (`--code-block-to-image-command`)
+2. Frontmatter setting (`codeBlockToImageCommand`)
+3. Configuration file setting (`codeBlockToImageCommand`)
+
 The command is executed with `bash -c`.
 The command must output image data (PNG, JPEG, GIF) to standard output.
 
@@ -413,13 +436,13 @@ $ deck apply -c 'mmdc -i - -o {{output}} --quiet' -i xxxxxXXXXxxxxxXXXXxxxxxxxxx
 ```
 
 ```console
-# Generate code images with syntax highlighting (e.g., silicon)
-$ deck apply -c 'silicon -l {{lang == "" ? "md" : lang}} -o {{output}}' -i xxxxxXXXXxxxxxXXXXxxxxxxxxxx deck.md
+# Generate code images using the built-in text-to-image tool
+$ deck apply -c 'go run testdata/txt2img/main.go' -i xxxxxXXXXxxxxxXXXXxxxxxxxxxx deck.md
 ```
 
 ```console
 # Use different tools depending on the language
-$ deck apply -c 'if [ {{lang}} = "mermaid" ]; then mmdc -i - -o {{output}} --quiet; else silicon -l {{lang == "" ? "md" : lang}} --output {{output}}; fi' -i xxxxxXXXXxxxxxXXXXxxxxxxxxxx deck.md
+$ deck apply -c 'if [ {{lang}} = "mermaid" ]; then mmdc -i - -o {{output}} --quiet; else go run testdata/txt2img/main.go; fi' -i xxxxxXXXXxxxxxXXXXxxxxxxxxxx deck.md
 ```
 
 ### Comment

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	Breaks *bool `yaml:"breaks,omitempty" json:"breaks,omitempty"`
 	// Conditions for default
 	Defaults []DefaultCondition `yaml:"defaults,omitempty" json:"defaults,omitempty"`
+	// command to convert code blocks to images
+	CodeBlockToImageCommand string `yaml:"codeBlockToImageCommand,omitempty" json:"codeBlockToImageCommand,omitempty"`
 }
 
 type DefaultCondition struct {

--- a/md/md.go
+++ b/md/md.go
@@ -55,6 +55,8 @@ type Frontmatter struct {
 	Breaks *bool `yaml:"breaks,omitempty" json:"breaks,omitempty"`
 	// Conditions for default
 	Defaults []DefaultCondition `yaml:"defaults,omitempty" json:"defaults,omitempty"`
+	// command to convert code blocks to images
+	CodeBlockToImageCommand string `yaml:"codeBlockToImageCommand,omitempty" json:"codeBlockToImageCommand,omitempty"`
 }
 
 type DefaultCondition struct {
@@ -229,6 +231,9 @@ func (md *MD) ApplyConfig(cfg *config.Config) {
 	if md.Frontmatter.Breaks == nil {
 		md.Frontmatter.Breaks = cfg.Breaks
 	}
+	if md.Frontmatter.CodeBlockToImageCommand == "" {
+		md.Frontmatter.CodeBlockToImageCommand = cfg.CodeBlockToImageCommand
+	}
 	// append default conditions from config
 	for _, cond := range cfg.Defaults {
 		md.Frontmatter.Defaults = append(md.Frontmatter.Defaults, DefaultCondition{
@@ -264,6 +269,9 @@ func (md *MD) ToSlides(ctx context.Context, codeBlockToImageCmd string) (_ deck.
 	}
 	if md.Frontmatter == nil {
 		return md.Contents.toSlides(ctx, codeBlockToImageCmd)
+	}
+	if codeBlockToImageCmd == "" {
+		codeBlockToImageCmd = md.Frontmatter.CodeBlockToImageCommand
 	}
 	pageTotal := len(md.Contents)
 	for i, content := range md.Contents {


### PR DESCRIPTION
This pull request introduces a new feature that allows users to convert code blocks in markdown presentations into images using a configurable command. The changes span documentation updates, configuration enhancements, and test additions to ensure the feature works as intended.

### Documentation Updates:
* Added `codeBlockToImageCommand` as a new frontmatter and configuration option in `README.md`, explaining its purpose, usage, and precedence order [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R145) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R162) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R182) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R366-R385).
* Updated examples in `README.md` to demonstrate how to use the `codeBlockToImageCommand` option with different tools.

### Configuration Enhancements:
* Introduced `CodeBlockToImageCommand` field in the `Config` struct in `config/config.go`.
* Added support for `CodeBlockToImageCommand` in the `Frontmatter` struct and ensured it inherits values from the global configuration if not explicitly set [[1]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R58-R59) [[2]](diffhunk://#diff-f10e982d75ada71772b6eea3f470a79ccdb670e48b51e202deb638bf61b80517R234-R236).

### Code Logic Updates:
* Updated the `ToSlides` method to prioritize the command-line argument, followed by frontmatter, and then global configuration for the `codeBlockToImageCommand`.

### Test Additions:
* Added unit tests to validate the inheritance and precedence of `CodeBlockToImageCommand` between configuration, frontmatter, and command-line arguments [[1]](diffhunk://#diff-a875d3534d9727c49cb3453f84caac0054354cf1d674fd78fd638afc7593ecf8R188-R224) [[2]](diffhunk://#diff-a875d3534d9727c49cb3453f84caac0054354cf1d674fd78fd638afc7593ecf8R321-R402).