### PR TITLE
fix: issue where all pages are listed as diff pages in DiffContents due to the `defaults` setting

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -80,15 +80,14 @@ var applyCmd = &cobra.Command{
 			presentationID = args[0]
 			f = args[1]
 		}
-		m, err := md.ParseFile(f)
-		if err != nil {
-			return err
-		}
 		cfg, err := config.Load(profile)
 		if err != nil {
 			return fmt.Errorf("failed to load config: %w", err)
 		}
-		m.ApplyConfig(cfg)
+		m, err := md.ParseFile(f, cfg)
+		if err != nil {
+			return err
+		}
 		if len(args) == 1 {
 			if m.Frontmatter != nil {
 				if presentationID == "" && m.Frontmatter.PresentationID != "" {
@@ -311,7 +310,7 @@ func watchFile(ctx context.Context, cfg *config.Config, filePath string, oldCont
 			}
 			logger.Info("file modified", slog.String("file", fileName))
 
-			newMD, err := md.ParseFile(filePath)
+			newMD, err := md.ParseFile(filePath, cfg)
 			if err != nil {
 				logger.Error("failed to parse file", slog.String("error", err.Error()))
 				continue
@@ -324,7 +323,6 @@ func watchFile(ctx context.Context, cfg *config.Config, filePath string, oldCont
 			}
 
 			logger.Info("detected changes", slog.Any("pages", changedPages))
-			newMD.ApplyConfig(cfg)
 			slides, err := newMD.ToSlides(ctx, codeBlockToImageCmd)
 			if err != nil {
 				logger.Error("failed to convert markdown contents to slides", slog.String("error", err.Error()))

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -42,7 +42,7 @@ var exportCmd = &cobra.Command{
 		ctx := cmd.Context()
 		if len(args) > 0 {
 			f := args[0]
-			markdownData, err := md.ParseFile(f)
+			markdownData, err := md.ParseFile(f, nil)
 			if err != nil {
 				// Deprecated
 				presentationID = f

--- a/cmd/lsLayouts.go
+++ b/cmd/lsLayouts.go
@@ -39,7 +39,7 @@ var lsLayoutsCmd = &cobra.Command{
 		ctx := cmd.Context()
 		if len(args) > 0 {
 			f := args[0]
-			markdownData, err := md.ParseFile(f)
+			markdownData, err := md.ParseFile(f, nil)
 			if err != nil {
 				// Deprecated
 				presentationID = f

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -21,7 +21,7 @@ var openCmd = &cobra.Command{
 
 		if len(args) == 1 {
 			f := args[0]
-			markdownData, err := md.ParseFile(f)
+			markdownData, err := md.ParseFile(f, nil)
 			if err != nil {
 				return err
 			}

--- a/integration_test.go
+++ b/integration_test.go
@@ -71,7 +71,7 @@ func TestApplyMarkdown(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			m, err := md.Parse("testdata", b)
+			m, err := md.Parse("testdata", b, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -201,7 +201,7 @@ func TestRoundTripSlidesToGoogleSlidesPresentationAndBack(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			m, err := md.Parse("testdata", b)
+			m, err := md.Parse("testdata", b, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/md/cel.go
+++ b/md/cel.go
@@ -1,0 +1,93 @@
+package md
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+)
+
+// Regular expression to match {{expression}} patterns.
+var celExprReg = regexp.MustCompile(`\{\{([^}]+)\}\}`)
+
+// expandTemplate expands template expressions in the format {{CEL expression}} with values from the store.
+// It supports CEL (Common Expression Language) expressions within the template.
+func expandTemplate(template string, store map[string]any) (string, error) {
+	// Create CEL environment with store variables
+	env, err := createCELEnv(store)
+	if err != nil {
+		return "", fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+
+	var expandErr error
+	result := celExprReg.ReplaceAllStringFunc(template, func(match string) string {
+		// Extract CEL expression without {{ }}
+		expr := strings.TrimSpace(match[2 : len(match)-2])
+
+		// Compile and evaluate CEL expression
+		ast, issues := env.Compile(expr)
+		if issues != nil && issues.Err() != nil {
+			expandErr = fmt.Errorf("template compilation error for '{{%s}}': %w", expr, issues.Err())
+			return match // Return original match on error
+		}
+
+		prg, err := env.Program(ast)
+		if err != nil {
+			expandErr = fmt.Errorf("template program creation error for '{{%s}}': %w", expr, err)
+			return match // Return original match on error
+		}
+
+		out, _, err := prg.Eval(store)
+		if err != nil {
+			expandErr = fmt.Errorf("template evaluation error for '{{%s}}': %w", expr, err)
+			return match // Return original match on error
+		}
+
+		// Convert result to string
+		return fmt.Sprintf("%v", out.Value())
+	})
+
+	if expandErr != nil {
+		return "", expandErr
+	}
+
+	return result, nil
+}
+
+// createCELEnv creates a CEL environment with all variables from the store.
+func createCELEnv(store map[string]any) (*cel.Env, error) {
+	var options []cel.EnvOption
+
+	// Add each top-level store key as a CEL variable
+	for key, value := range store {
+		celType := inferCELType(value)
+		options = append(options, cel.Variable(key, celType))
+	}
+
+	return cel.NewEnv(options...)
+}
+
+// inferCELType infers the CEL type from a Go value.
+func inferCELType(value any) *cel.Type {
+	switch value.(type) {
+	case string:
+		return cel.StringType
+	case int, int32, int64:
+		return cel.IntType
+	case float32, float64:
+		return cel.DoubleType
+	case bool:
+		return cel.BoolType
+	case map[string]any:
+		return cel.MapType(cel.StringType, cel.AnyType)
+	case map[string]string:
+		return cel.MapType(cel.StringType, cel.StringType)
+	case []any:
+		return cel.ListType(cel.AnyType)
+	case []string:
+		return cel.ListType(cel.StringType)
+	default:
+		return cel.AnyType
+	}
+}

--- a/md/cel.go
+++ b/md/cel.go
@@ -8,6 +8,92 @@ import (
 	"github.com/google/cel-go/cel"
 )
 
+func (md *MD) reflectDefaults() error {
+	env, err := cel.NewEnv(
+		cel.Variable("page", cel.IntType),
+		cel.Variable("pageTotal", cel.IntType),
+		cel.Variable("titles", cel.ListType(cel.StringType)),
+		cel.Variable("subtitles", cel.ListType(cel.StringType)),
+		cel.Variable("bodies", cel.ListType(cel.StringType)),
+		cel.Variable("blockQuotes", cel.ListType(cel.StringType)),
+		cel.Variable("codeBlocks", cel.ListType(cel.ObjectType("deck.CodeBlock"))),
+		cel.Variable("images", cel.ListType(cel.ObjectType("deck.Image"))),
+		cel.Variable("comments", cel.ListType(cel.StringType)),
+		cel.Variable("headings", cel.MapType(cel.IntType, cel.ListType(cel.StringType))),
+		cel.Variable("speakerNote", cel.StringType),
+		cel.Variable("topHeadingLevel", cel.IntType),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create environment: %w", err)
+	}
+	pageTotal := len(md.Contents)
+	for i, content := range md.Contents {
+		for _, cond := range md.Frontmatter.Defaults {
+			ast, issues := env.Compile(fmt.Sprintf("!!(%s)", cond.If))
+			if issues != nil && issues.Err() != nil {
+				return fmt.Errorf("failed to compile expression: %w", issues.Err())
+			}
+			prg, err := env.Program(ast)
+			if err != nil {
+				return fmt.Errorf("failed to create program: %w", err)
+			}
+			var bodies []string
+			for _, body := range content.Bodies {
+				bodies = append(bodies, body.String())
+			}
+			var blockQuotes []string
+			for _, blockQuote := range content.BlockQuotes {
+				blockQuotes = append(blockQuotes, blockQuote.String())
+			}
+			for j := 1; j < sentinelLevel; j++ {
+				if _, ok := content.Headings[j]; !ok {
+					content.Headings[j] = []string{}
+				}
+			}
+			var topHeadingLevel int
+			for j := 1; j < sentinelLevel; j++ {
+				if len(content.Headings[j]) > 0 {
+					topHeadingLevel = j
+					break
+				}
+			}
+			out, _, err := prg.Eval(map[string]any{
+				"page":            i + 1,
+				"pageTotal":       pageTotal,
+				"titles":          content.Titles,
+				"subtitles":       content.Subtitles,
+				"bodies":          bodies,
+				"blockQuotes":     blockQuotes,
+				"codeBlocks":      content.CodeBlocks,
+				"images":          content.Images,
+				"comments":        content.Comments,
+				"headings":        content.Headings,
+				"speakerNote":     strings.Join(content.Comments, "\n\n"),
+				"topHeadingLevel": topHeadingLevel,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to evaluate values: %w", err)
+			}
+			if tf, ok := out.Value().(bool); ok && tf {
+				if content.Layout == "" {
+					content.Layout = cond.Layout
+				}
+				if content.Freeze == nil && cond.Freeze != nil {
+					content.Freeze = cond.Freeze
+				}
+				if content.Ignore == nil && cond.Ignore != nil {
+					content.Ignore = cond.Ignore
+				}
+				if content.Skip == nil && cond.Skip != nil {
+					content.Skip = cond.Skip
+				}
+				break // Use the first matching condition
+			}
+		}
+	}
+	return nil
+}
+
 // Regular expression to match {{expression}} patterns.
 var celExprReg = regexp.MustCompile(`\{\{([^}]+)\}\}`)
 

--- a/md/cel.go
+++ b/md/cel.go
@@ -9,6 +9,9 @@ import (
 )
 
 func (md *MD) reflectDefaults() error {
+	if md.Frontmatter == nil {
+		return nil
+	}
 	env, err := cel.NewEnv(
 		cel.Variable("page", cel.IntType),
 		cel.Variable("pageTotal", cel.IntType),

--- a/md/frontmatter.go
+++ b/md/frontmatter.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 
 	"github.com/goccy/go-yaml"
+	"github.com/k1LoW/deck/config"
 	"github.com/k1LoW/errors"
 )
 
@@ -79,4 +81,30 @@ func ApplyFrontmatterToMD(mdFile, title, presentationID string) (err error) {
 		return fmt.Errorf("failed to write file: %w", err)
 	}
 	return nil
+}
+
+func (fm *Frontmatter) applyConfig(cfg *config.Config) *Frontmatter {
+	if cfg == nil || reflect.DeepEqual(*cfg, config.Config{}) {
+		return fm
+	}
+	if fm == nil {
+		fm = &Frontmatter{}
+	}
+	if fm.Breaks == nil {
+		fm.Breaks = cfg.Breaks
+	}
+	if fm.CodeBlockToImageCommand == "" {
+		fm.CodeBlockToImageCommand = cfg.CodeBlockToImageCommand
+	}
+	// append default conditions from config
+	for _, cond := range cfg.Defaults {
+		fm.Defaults = append(fm.Defaults, DefaultCondition{
+			If:     cond.If,
+			Layout: cond.Layout,
+			Freeze: cond.Freeze,
+			Ignore: cond.Ignore,
+			Skip:   cond.Skip,
+		})
+	}
+	return fm
 }

--- a/md/frontmatter_test.go
+++ b/md/frontmatter_test.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/k1LoW/deck/config"
 )
 
 func TestFrontmatter(t *testing.T) {
@@ -70,7 +73,7 @@ tags:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			md, err := Parse(".", []byte(tt.markdown))
+			md, err := Parse(".", []byte(tt.markdown), nil)
 			if err != nil {
 				t.Fatalf("Parse() error = %v", err)
 			}
@@ -217,5 +220,170 @@ func TestApplyFrontmatterToMD_CreateDirectory(t *testing.T) {
 	// Check if file exists
 	if _, err := os.Stat(nestedFile); os.IsNotExist(err) {
 		t.Errorf("File was not created: %s", nestedFile)
+	}
+}
+
+func TestApplyConfig(t *testing.T) {
+	tests := []struct {
+		name               string
+		initialFrontmatter *Frontmatter
+		config             *config.Config
+		want               *Frontmatter
+	}{
+		{
+			name: "Apply config breaks when frontmatter breaks is not set",
+			initialFrontmatter: &Frontmatter{
+				Breaks: nil, // not set
+			},
+			config: &config.Config{
+				Breaks: boolPtr(true),
+			},
+			want: &Frontmatter{
+				Breaks:   boolPtr(true),
+				Defaults: nil,
+			},
+		},
+		{
+			name: "Keep existing breaks value when already set",
+			initialFrontmatter: &Frontmatter{
+				Breaks: boolPtr(false), // already set
+			},
+			config: &config.Config{
+				Breaks: boolPtr(true),
+			},
+			want: &Frontmatter{
+				Breaks:   boolPtr(false), // keep existing value
+				Defaults: nil,
+			},
+		},
+		{
+			name:               "Apply breaks when frontmatter is nil",
+			initialFrontmatter: nil,
+			config: &config.Config{
+				Breaks: boolPtr(true),
+			},
+			want: &Frontmatter{
+				Breaks:   boolPtr(true),
+				Defaults: nil,
+			},
+		},
+		{
+			name: "Add config defaults when no existing defaults conditions",
+			initialFrontmatter: &Frontmatter{
+				Defaults: []DefaultCondition{}, // empty slice
+			},
+			config: &config.Config{
+				Defaults: []config.DefaultCondition{
+					{
+						If:     "page == 1",
+						Layout: "title",
+						Freeze: boolPtr(true),
+					},
+				},
+			},
+			want: &Frontmatter{
+				Breaks: nil,
+				Defaults: []DefaultCondition{
+					{
+						If:     "page == 1",
+						Layout: "title",
+						Freeze: boolPtr(true),
+					},
+				},
+			},
+		},
+		{
+			name: "Append config defaults when existing defaults conditions present",
+			initialFrontmatter: &Frontmatter{
+				Defaults: []DefaultCondition{
+					{
+						If:     "page == 2",
+						Layout: "content",
+						Skip:   boolPtr(true),
+					},
+				},
+			},
+			config: &config.Config{
+				Defaults: []config.DefaultCondition{
+					{
+						If:     "page == 1",
+						Layout: "title",
+						Freeze: boolPtr(true),
+					},
+					{
+						If:     "page == 3",
+						Layout: "end",
+						Ignore: boolPtr(true),
+					},
+				},
+			},
+			want: &Frontmatter{
+				Breaks: nil,
+				Defaults: []DefaultCondition{
+					{
+						If:     "page == 2",
+						Layout: "content",
+						Skip:   boolPtr(true),
+					},
+					{
+						If:     "page == 1",
+						Layout: "title",
+						Freeze: boolPtr(true),
+					},
+					{
+						If:     "page == 3",
+						Layout: "end",
+						Ignore: boolPtr(true),
+					},
+				},
+			},
+		},
+		{
+			name: "Apply config codeBlockToImageCommand when frontmatter codeBlockToImageCommand is not set",
+			initialFrontmatter: &Frontmatter{
+				CodeBlockToImageCommand: "", // not set
+			},
+			config: &config.Config{
+				CodeBlockToImageCommand: "go run testdata/txt2img/main.go",
+			},
+			want: &Frontmatter{
+				CodeBlockToImageCommand: "go run testdata/txt2img/main.go",
+				Defaults:                nil,
+			},
+		},
+		{
+			name: "Keep existing codeBlockToImageCommand value when already set",
+			initialFrontmatter: &Frontmatter{
+				CodeBlockToImageCommand: "go run testdata/txt2img/main.go", // already set
+			},
+			config: &config.Config{
+				CodeBlockToImageCommand: "go run other/command",
+			},
+			want: &Frontmatter{
+				CodeBlockToImageCommand: "go run testdata/txt2img/main.go", // keep existing value
+				Defaults:                nil,
+			},
+		},
+		{
+			name:               "Apply codeBlockToImageCommand when frontmatter is nil",
+			initialFrontmatter: nil,
+			config: &config.Config{
+				CodeBlockToImageCommand: "go run testdata/txt2img/main.go",
+			},
+			want: &Frontmatter{
+				CodeBlockToImageCommand: "go run testdata/txt2img/main.go",
+				Defaults:                nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.initialFrontmatter.applyConfig(tt.config)
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Frontmatter mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/md/md.go
+++ b/md/md.go
@@ -919,11 +919,8 @@ func jsonEqual[T any](a, b T) bool {
 
 // contentEqual compares two Content structs and returns true if they are equal.
 func contentEqual(old, new *Content) bool {
-	if old == nil && new == nil {
-		return true
-	}
 	if old == nil || new == nil {
-		return false
+		return old == new
 	}
 
 	// Compare layout and freeze flag
@@ -1091,88 +1088,4 @@ func environToMap() map[string]string {
 		}
 	}
 	return envMap
-}
-
-// Regular expression to match {{expression}} patterns.
-var celExprReg = regexp.MustCompile(`\{\{([^}]+)\}\}`)
-
-// expandTemplate expands template expressions in the format {{CEL expression}} with values from the store.
-// It supports CEL (Common Expression Language) expressions within the template.
-func expandTemplate(template string, store map[string]any) (string, error) {
-	// Create CEL environment with store variables
-	env, err := createCELEnv(store)
-	if err != nil {
-		return "", fmt.Errorf("failed to create CEL environment: %w", err)
-	}
-
-	var expandErr error
-	result := celExprReg.ReplaceAllStringFunc(template, func(match string) string {
-		// Extract CEL expression without {{ }}
-		expr := strings.TrimSpace(match[2 : len(match)-2])
-
-		// Compile and evaluate CEL expression
-		ast, issues := env.Compile(expr)
-		if issues != nil && issues.Err() != nil {
-			expandErr = fmt.Errorf("template compilation error for '{{%s}}': %w", expr, issues.Err())
-			return match // Return original match on error
-		}
-
-		prg, err := env.Program(ast)
-		if err != nil {
-			expandErr = fmt.Errorf("template program creation error for '{{%s}}': %w", expr, err)
-			return match // Return original match on error
-		}
-
-		out, _, err := prg.Eval(store)
-		if err != nil {
-			expandErr = fmt.Errorf("template evaluation error for '{{%s}}': %w", expr, err)
-			return match // Return original match on error
-		}
-
-		// Convert result to string
-		return fmt.Sprintf("%v", out.Value())
-	})
-
-	if expandErr != nil {
-		return "", expandErr
-	}
-
-	return result, nil
-}
-
-// createCELEnv creates a CEL environment with all variables from the store.
-func createCELEnv(store map[string]any) (*cel.Env, error) {
-	var options []cel.EnvOption
-
-	// Add each top-level store key as a CEL variable
-	for key, value := range store {
-		celType := inferCELType(value)
-		options = append(options, cel.Variable(key, celType))
-	}
-
-	return cel.NewEnv(options...)
-}
-
-// inferCELType infers the CEL type from a Go value.
-func inferCELType(value any) *cel.Type {
-	switch value.(type) {
-	case string:
-		return cel.StringType
-	case int, int32, int64:
-		return cel.IntType
-	case float32, float64:
-		return cel.DoubleType
-	case bool:
-		return cel.BoolType
-	case map[string]any:
-		return cel.MapType(cel.StringType, cel.AnyType)
-	case map[string]string:
-		return cel.MapType(cel.StringType, cel.StringType)
-	case []any:
-		return cel.ListType(cel.AnyType)
-	case []string:
-		return cel.ListType(cel.StringType)
-	default:
-		return cel.AnyType
-	}
 }

--- a/md/md.go
+++ b/md/md.go
@@ -160,10 +160,14 @@ func Parse(baseDir string, b []byte, cfg *config.Config) (_ *MD, err error) {
 		contents = append(contents, c)
 	}
 
-	return &MD{
+	md := &MD{
 		Frontmatter: frontmatter,
 		Contents:    contents,
-	}, nil
+	}
+	if err := md.reflectDefaults(); err != nil {
+		return nil, fmt.Errorf("failed to reflect defaults while parsing: %w", err)
+	}
+	return md, nil
 }
 
 // ParseContent parses a single markdown content into a Content structure.
@@ -228,14 +232,8 @@ func (md *MD) ToSlides(ctx context.Context, codeBlockToImageCmd string) (_ deck.
 	defer func() {
 		err = errors.WithStack(err)
 	}()
-	if md.Frontmatter == nil {
-		return md.Contents.toSlides(ctx, codeBlockToImageCmd)
-	}
-	if codeBlockToImageCmd == "" {
+	if codeBlockToImageCmd == "" && md.Frontmatter != nil {
 		codeBlockToImageCmd = md.Frontmatter.CodeBlockToImageCommand
-	}
-	if err := md.reflectDefaults(); err != nil {
-		return nil, fmt.Errorf("failed to reflect defaults: %w", err)
 	}
 	return md.Contents.toSlides(ctx, codeBlockToImageCmd)
 }

--- a/md/md.go
+++ b/md/md.go
@@ -787,11 +787,7 @@ func DiffContents(oldContents, newContents Contents) []int {
 		}
 
 		// Compare the content of the pages
-		if !contentEqual(oldContents[i], newContents[i]) {
-			if newContents[i].Freeze != nil && *newContents[i].Freeze {
-				// The frozen page is considered unchanged
-				continue
-			}
+		if (newContents[i].Freeze == nil || !*newContents[i].Freeze) && !contentEqual(oldContents[i], newContents[i]) {
 			changedPages = append(changedPages, i+1) // 1-indexed
 		}
 	}
@@ -818,7 +814,7 @@ func contentEqual(old, new *Content) bool {
 	}
 
 	// Compare layout and freeze flag
-	if old.Layout != new.Layout || old.Freeze != new.Freeze {
+	if old.Layout != new.Layout || old.Freeze != new.Freeze || old.Skip != new.Skip {
 		return false
 	}
 

--- a/md/md.go
+++ b/md/md.go
@@ -843,7 +843,7 @@ func contentEqual(old, new *Content) bool {
 	}
 
 	// Compare bodies
-	if len(old.Bodies) != len(new.Bodies) {
+	if !jsonEqual(old.Bodies, new.Bodies) {
 		return false
 	}
 

--- a/md/md.go
+++ b/md/md.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 
 	"github.com/goccy/go-yaml"
-	"github.com/google/cel-go/cel"
 	"github.com/k1LoW/deck"
 	"github.com/k1LoW/deck/config"
 	"github.com/k1LoW/errors"
@@ -253,93 +252,14 @@ func (md *MD) ToSlides(ctx context.Context, codeBlockToImageCmd string) (_ deck.
 	defer func() {
 		err = errors.WithStack(err)
 	}()
-	env, err := cel.NewEnv(
-		cel.Variable("page", cel.IntType),
-		cel.Variable("pageTotal", cel.IntType),
-		cel.Variable("titles", cel.ListType(cel.StringType)),
-		cel.Variable("subtitles", cel.ListType(cel.StringType)),
-		cel.Variable("bodies", cel.ListType(cel.StringType)),
-		cel.Variable("blockQuotes", cel.ListType(cel.StringType)),
-		cel.Variable("codeBlocks", cel.ListType(cel.ObjectType("deck.CodeBlock"))),
-		cel.Variable("images", cel.ListType(cel.ObjectType("deck.Image"))),
-		cel.Variable("comments", cel.ListType(cel.StringType)),
-		cel.Variable("headings", cel.MapType(cel.IntType, cel.ListType(cel.StringType))),
-		cel.Variable("speakerNote", cel.StringType),
-		cel.Variable("topHeadingLevel", cel.IntType),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create environment: %w", err)
-	}
 	if md.Frontmatter == nil {
 		return md.Contents.toSlides(ctx, codeBlockToImageCmd)
 	}
 	if codeBlockToImageCmd == "" {
 		codeBlockToImageCmd = md.Frontmatter.CodeBlockToImageCommand
 	}
-	pageTotal := len(md.Contents)
-	for i, content := range md.Contents {
-		for _, cond := range md.Frontmatter.Defaults {
-			ast, issues := env.Compile(fmt.Sprintf("!!(%s)", cond.If))
-			if issues != nil && issues.Err() != nil {
-				return nil, fmt.Errorf("failed to compile expression: %w", issues.Err())
-			}
-			prg, err := env.Program(ast)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create program: %w", err)
-			}
-			var bodies []string
-			for _, body := range content.Bodies {
-				bodies = append(bodies, body.String())
-			}
-			var blockQuotes []string
-			for _, blockQuote := range content.BlockQuotes {
-				blockQuotes = append(blockQuotes, blockQuote.String())
-			}
-			for j := 1; j < sentinelLevel; j++ {
-				if _, ok := content.Headings[j]; !ok {
-					content.Headings[j] = []string{}
-				}
-			}
-			var topHeadingLevel int
-			for j := 1; j < sentinelLevel; j++ {
-				if len(content.Headings[j]) > 0 {
-					topHeadingLevel = j
-					break
-				}
-			}
-			out, _, err := prg.Eval(map[string]any{
-				"page":            i + 1,
-				"pageTotal":       pageTotal,
-				"titles":          content.Titles,
-				"subtitles":       content.Subtitles,
-				"bodies":          bodies,
-				"blockQuotes":     blockQuotes,
-				"codeBlocks":      content.CodeBlocks,
-				"images":          content.Images,
-				"comments":        content.Comments,
-				"headings":        content.Headings,
-				"speakerNote":     strings.Join(content.Comments, "\n\n"),
-				"topHeadingLevel": topHeadingLevel,
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed to evaluate values: %w", err)
-			}
-			if tf, ok := out.Value().(bool); ok && tf {
-				if content.Layout == "" {
-					content.Layout = cond.Layout
-				}
-				if content.Freeze == nil && cond.Freeze != nil {
-					content.Freeze = cond.Freeze
-				}
-				if content.Ignore == nil && cond.Ignore != nil {
-					content.Ignore = cond.Ignore
-				}
-				if content.Skip == nil && cond.Skip != nil {
-					content.Skip = cond.Skip
-				}
-				break // Use the first matching condition
-			}
-		}
+	if err := md.reflectDefaults(); err != nil {
+		return nil, fmt.Errorf("failed to reflect defaults: %w", err)
 	}
 	return md.Contents.toSlides(ctx, codeBlockToImageCmd)
 }

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -8,8 +8,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/k1LoW/deck/config"
 	"github.com/tenntenn/golden"
 )
 
@@ -52,7 +50,7 @@ func TestParse(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			md, err := Parse("../testdata", b)
+			md, err := Parse("../testdata", b, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -66,175 +64,6 @@ func TestParse(t *testing.T) {
 			}
 			if diff := golden.Diff(t, "", tt.in, got); diff != "" {
 				t.Error(diff)
-			}
-		})
-	}
-}
-
-func TestApplyConfig(t *testing.T) {
-	tests := []struct {
-		name               string
-		initialFrontmatter *Frontmatter
-		config             *config.Config
-		want               *Frontmatter
-	}{
-		{
-			name: "Apply config breaks when frontmatter breaks is not set",
-			initialFrontmatter: &Frontmatter{
-				Breaks: nil, // not set
-			},
-			config: &config.Config{
-				Breaks: boolPtr(true),
-			},
-			want: &Frontmatter{
-				Breaks:   boolPtr(true),
-				Defaults: nil,
-			},
-		},
-		{
-			name: "Keep existing breaks value when already set",
-			initialFrontmatter: &Frontmatter{
-				Breaks: boolPtr(false), // already set
-			},
-			config: &config.Config{
-				Breaks: boolPtr(true),
-			},
-			want: &Frontmatter{
-				Breaks:   boolPtr(false), // keep existing value
-				Defaults: nil,
-			},
-		},
-		{
-			name:               "Apply breaks when frontmatter is nil",
-			initialFrontmatter: nil,
-			config: &config.Config{
-				Breaks: boolPtr(true),
-			},
-			want: &Frontmatter{
-				Breaks:   boolPtr(true),
-				Defaults: nil,
-			},
-		},
-		{
-			name: "Add config defaults when no existing defaults conditions",
-			initialFrontmatter: &Frontmatter{
-				Defaults: []DefaultCondition{}, // empty slice
-			},
-			config: &config.Config{
-				Defaults: []config.DefaultCondition{
-					{
-						If:     "page == 1",
-						Layout: "title",
-						Freeze: boolPtr(true),
-					},
-				},
-			},
-			want: &Frontmatter{
-				Breaks: nil,
-				Defaults: []DefaultCondition{
-					{
-						If:     "page == 1",
-						Layout: "title",
-						Freeze: boolPtr(true),
-					},
-				},
-			},
-		},
-		{
-			name: "Append config defaults when existing defaults conditions present",
-			initialFrontmatter: &Frontmatter{
-				Defaults: []DefaultCondition{
-					{
-						If:     "page == 2",
-						Layout: "content",
-						Skip:   boolPtr(true),
-					},
-				},
-			},
-			config: &config.Config{
-				Defaults: []config.DefaultCondition{
-					{
-						If:     "page == 1",
-						Layout: "title",
-						Freeze: boolPtr(true),
-					},
-					{
-						If:     "page == 3",
-						Layout: "end",
-						Ignore: boolPtr(true),
-					},
-				},
-			},
-			want: &Frontmatter{
-				Breaks: nil,
-				Defaults: []DefaultCondition{
-					{
-						If:     "page == 2",
-						Layout: "content",
-						Skip:   boolPtr(true),
-					},
-					{
-						If:     "page == 1",
-						Layout: "title",
-						Freeze: boolPtr(true),
-					},
-					{
-						If:     "page == 3",
-						Layout: "end",
-						Ignore: boolPtr(true),
-					},
-				},
-			},
-		},
-		{
-			name: "Apply config codeBlockToImageCommand when frontmatter codeBlockToImageCommand is not set",
-			initialFrontmatter: &Frontmatter{
-				CodeBlockToImageCommand: "", // not set
-			},
-			config: &config.Config{
-				CodeBlockToImageCommand: "go run testdata/txt2img/main.go",
-			},
-			want: &Frontmatter{
-				CodeBlockToImageCommand: "go run testdata/txt2img/main.go",
-				Defaults:                nil,
-			},
-		},
-		{
-			name: "Keep existing codeBlockToImageCommand value when already set",
-			initialFrontmatter: &Frontmatter{
-				CodeBlockToImageCommand: "go run testdata/txt2img/main.go", // already set
-			},
-			config: &config.Config{
-				CodeBlockToImageCommand: "go run other/command",
-			},
-			want: &Frontmatter{
-				CodeBlockToImageCommand: "go run testdata/txt2img/main.go", // keep existing value
-				Defaults:                nil,
-			},
-		},
-		{
-			name:               "Apply codeBlockToImageCommand when frontmatter is nil",
-			initialFrontmatter: nil,
-			config: &config.Config{
-				CodeBlockToImageCommand: "go run testdata/txt2img/main.go",
-			},
-			want: &Frontmatter{
-				CodeBlockToImageCommand: "go run testdata/txt2img/main.go",
-				Defaults:                nil,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			md := &MD{
-				Frontmatter: tt.initialFrontmatter,
-			}
-
-			md.ApplyConfig(tt.config)
-
-			if diff := cmp.Diff(tt.want, md.Frontmatter); diff != "" {
-				t.Errorf("Frontmatter mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -441,6 +270,6 @@ ref: [deck repo](https://github.com/k1LoW/deck)
 # Title
 `))
 	f.Fuzz(func(t *testing.T, in []byte) {
-		_, _ = Parse(".", in)
+		_, _ = Parse(".", in, nil)
 	})
 }


### PR DESCRIPTION
Currently, the `defaults` CEL is interpreted in `md.ToSlide`, but this process has the side effect of overwriting content.Layout. As a result, when `md.DiffContents` is called next, all overwritten pages are detected as diffs.

 I resolved the issue by modifying `md.Parse` and `md.ParseFile` to accept a config parameter, and moving the CEL interpretation logic to the inside of `md.Parse`. 

This fix introduces a slight incompatibility in the function interface. Still, I believe this approach is preferable to exposing `md.ApplyConfig` publicly.