### PR TITLE
fix: adjust configuration and data file placement rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ The frontmatter must be:
 
 `deck` supports global configuration files that provide default settings for all presentations. Configuration files are loaded in the following priority order:
 
-1. `$XDG_DATA_HOME/deck/config-{profile}.yml` (when using `--profile` option)
-2. `$XDG_DATA_HOME/deck/config.yml` (default config file)
+1. `${XDG_CONFIG_HOME:-~/.config}/deck/config-{profile}.yml` (when using `--profile` option)
+2. `${XDG_CONFIG_HOME:-~/.config}/deck/config.yml` (default config file)
 
 The configuration file uses YAML format and supports the same fields as frontmatter. Settings in frontmatter take precedence over configuration file settings, which in turn take precedence over built-in defaults.
 

--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,9 @@ func Load(profile string) (*Config, error) {
 	return cfg, nil
 }
 
+// On macOS, we use directories that conform to the XDG Base Directory instead of `os.UserConfigDir`
+// or `os.UserDataDir`, etc. It is more intuitive for CLI applications.
+
 var configHomePath = sync.OnceValue(func() string {
 	if v := os.Getenv("XDG_CONFIG_HOME"); v != "" {
 		return filepath.Join(v, "deck")


### PR DESCRIPTION
- Configuration files should be placed under `XDG_CONFIG_HOME`
- Use `os.UserHomeDir` instead of the `$HOME` environment variable for cross-platform compatibility
- Fixed an issue where `XDG_*` was being overwritten each time, even though it appeared to be being referenced
- use `sync.OnceValue` to avoid race conditions and simplify code

This is incompatible, but I think the original implementation is incorrect.

I plan to add Windows support after this. @k1LoW 