### PR TITLE
chore: improv the efficiency of screenshot capture during testing

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -13,23 +13,36 @@ const (
 	viewportHeight = 800
 )
 
+var browserCtx context.Context
+
+// InitChrome initializes and preloads a Chrome browser context for testing.
+func InitChrome(ctx context.Context) func() {
+	aCtx, aCancel := chromedp.NewExecAllocator(ctx, chromedp.DefaultExecAllocatorOptions[:]...)
+	var bCancel context.CancelFunc
+	browserCtx, bCancel = chromedp.NewContext(aCtx)
+	return func() {
+		bCancel()
+		aCancel()
+	}
+}
+
 func Screenshot(t *testing.T, url string) []byte {
 	t.Helper()
-	ctx, cancel := chromedp.NewContext(
-		context.Background(),
-	)
-	t.Cleanup(func() {
-		cancel()
-	})
-	ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
-	t.Cleanup(func() {
-		cancel()
-	})
+	var ctx = browserCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := chromedp.NewContext(ctx)
+	t.Cleanup(cancel)
+
+	ctx, cancel2 := context.WithTimeout(ctx, 30*time.Second)
+	t.Cleanup(cancel2)
+
 	var buf []byte
 	if err := chromedp.Run(ctx,
 		chromedp.EmulateViewport(viewportWidth, viewportHeight),
 		chromedp.Navigate(url),
-		chromedp.Sleep(2*time.Second),
+		chromedp.WaitReady("body", chromedp.ByQuery),
 		chromedp.FullScreenshot(&buf, 100),
 	); err != nil {
 		t.Fatalf("Failed to take screenshot: %v", err)

--- a/integration_test.go
+++ b/integration_test.go
@@ -32,6 +32,8 @@ func TestApplyMarkdown(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	browserClose := deck.InitChrome(ctx)
+	t.Cleanup(browserClose)
 
 	tests := []struct {
 		in string


### PR DESCRIPTION
We launch the chrome process in advance and reuse it.