### PR TITLE
chore: update and cleanup Makefile

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -32,6 +32,6 @@
 [tagpr]
 	vPrefix = true
 	releaseBranch = main
-  release = draft
+	release = draft
 	versionFile = version/version.go
 	command = "make prerelease_for_tagpr"


### PR DESCRIPTION
- GO111MODULE=on is no longer needed
- Remove OSNAME, no longer used
- Remove ghch installation, no longer used
    - BTW, you can use newer gh2changelog instead for similar needs
- Remove manual release tasks
    - prerelease and release, we've used tagpr GitHub Actions instead
- Add `fulltest` and `install` tasks
- Update `.PHONY`
- 
I think you have your own way of doing things, so I would like to hear your opinion. @k1LoW 