### PR TITLE
chore: enhance and filter error.json

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ builds:
   -
     id: deck-darwin
     ldflags:
-      - -s -w -X github.com/k1LoW/deck.version={{.Version}} -X github.com/k1LoW/deck.commit={{.FullCommit}} -X github.com/k1LoW/deck.date={{.Date}} -X github.com/k1LoW/deck/version.Version={{.Version}}
+      - -s -w -X github.com/k1LoW/deck/version.Revision={{.ShortCommit}}
     env:
       - CGO_ENABLED=0
     goos:
@@ -19,7 +19,7 @@ builds:
   -
     id: deck-windows
     ldflags:
-      - -s -w -X github.com/k1LoW/deck.version={{.Version}} -X github.com/k1LoW/deck.commit={{.FullCommit}} -X github.com/k1LoW/deck.date={{.Date}} -X github.com/k1LoW/deck/version.Version={{.Version}}
+      - -s -w -X github.com/k1LoW/deck/version.Revision={{.ShortCommit}}
     env:
       - CGO_ENABLED=0
     goos:
@@ -30,7 +30,7 @@ builds:
   -
     id: deck-linux
     ldflags:
-      - -s -w -X github.com/k1LoW/deck.version={{.Version}} -X github.com/k1LoW/deck.commit={{.FullCommit}} -X github.com/k1LoW/deck.date={{.Date}} -X github.com/k1LoW/deck/version.Version={{.Version}}
+      - -s -w -X github.com/k1LoW/deck/version.Revision={{.ShortCommit}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 PKG = github.com/k1LoW/deck
-COMMIT = $$(git describe --tags --always)
-DATE = $$(date '+%Y-%m-%d_%H:%M:%S%z')
+COMMIT = $(shell git rev-parse --short HEAD)
 
-BUILD_LDFLAGS = -X $(PKG).commit=$(COMMIT) -X $(PKG).date=$(DATE)
+BUILD_LDFLAGS = "-s -w -X $(PKG)/version.Revision=$(COMMIT)"
 
 default: test
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/k1LoW/deck/config"
@@ -64,6 +65,10 @@ func Execute() {
 		for _, line := range tb.Lines() {
 			// replace Google API URL last key with a placeholder
 			line = googleAPIURLRe.ReplaceAllString(line, "${1}**********************")
+			if strings.Contains(line, `"level":"DEBUG"`) && strings.Contains(line, `"request":`) {
+				// Skip debug logs that contain request details
+				continue
+			}
 			var m map[string]any
 			if err := json.Unmarshal([]byte(line), &m); err != nil {
 				latestLogs = append(latestLogs, line)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,7 +42,7 @@ var rootCmd = &cobra.Command{
 	Short:        "deck is a tool for creating deck using Markdown and Google Slides",
 	Long:         `deck is a tool for creating deck using Markdown and Google Slides.`,
 	SilenceUsage: true,
-	Version:      version.Version,
+	Version:      fmt.Sprintf("%s (rev:%s)", version.Version, version.Revision),
 }
 
 type errorData struct {
@@ -50,6 +50,7 @@ type errorData struct {
 	StackTraces any       `json:"stack_traces"`
 	CreatedAt   time.Time `json:"created_at"`
 	Version     string    `json:"version"`
+	Revision    string    `json:"revision"`
 }
 
 // https://slides.googleapis.com/v1/presentations/xxxxxx
@@ -75,6 +76,7 @@ func Execute() {
 			StackTraces: errors.StackTraces(err),
 			CreatedAt:   time.Now(),
 			Version:     version.Version,
+			Revision:    version.Revision,
 		}
 		b, err := json.Marshal(d)
 		if err != nil {

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,8 @@
 package version
 
-const Name string = "deck"
+const (
+	Name    = "deck"
+	Version = "1.13.1"
+)
 
-var Version = "1.13.1" //nostyle:repetition
+var Revision = "HEAD"


### PR DESCRIPTION
I noticed in #363 that the contents of the user's content included in the request are included in error.json. This was not very good, so I decided to filter it out of the output. This change to the request output was made in #348.

In addition, to enhance error messages, I embedded the commit hash in the executable file. At the same time, I made the following changes.

- Constant definition of version.Version
    - This is incremented by tagpr, so it does not need to be specified at build time
- Removal of unnecessary build variables
    - `deck.version`, `deck.date`, and `deck.commit` were removed from the build configuration as they were not declared in the code.