### PR TITLE
fix: resolving inconsistencies in the information structure of list bullets

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -833,9 +833,7 @@ func convertBullet(b Bullet) string {
 	switch b {
 	case BulletDash:
 		return "BULLET_DISC_CIRCLE_SQUARE"
-	case BulletNumber:
-		return "NUMBERED_DIGIT_ALPHA_ROMAN"
-	case BulletAlpha:
+	case BulletNumbered:
 		return "NUMBERED_DIGIT_ALPHA_ROMAN"
 	default:
 		return "UNRECOGNIZED"
@@ -847,20 +845,10 @@ func getBulletPresetFromSlidesBullet(bullet *slides.Bullet) Bullet {
 	if bullet == nil || bullet.Glyph == "" {
 		return BulletNone
 	}
-
 	glyph := bullet.Glyph
-	// Check for numbered bullets (1, 2, 3, etc.)
-	for _, digit := range "0123456789" {
-		if strings.Contains(glyph, string(digit)) {
-			return BulletNumber
-		}
+	if numberedBulletReg.MatchString(glyph) {
+		return BulletNumbered
 	}
-
-	// Check for alphabetic bullets (a., A., etc.)
-	if strings.ContainsAny(glyph, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") {
-		return BulletAlpha
-	}
-
 	// Default to disc/circle/square bullets
 	return BulletDash
 }

--- a/convert.go
+++ b/convert.go
@@ -2,6 +2,7 @@
 package deck
 
 import (
+	"regexp"
 	"strings"
 
 	"google.golang.org/api/slides/v1"
@@ -121,6 +122,9 @@ func extractText(text *slides.TextContent) string {
 	return strings.TrimSpace(str)
 }
 
+// Regexp to match numberd (ordered) bullet points. (e.g., "1.", "2.", "A.", "B.", "a.", "b.", "i.", "ii.", "iii.").
+var numberedBulletReg = regexp.MustCompile(`^(?:[0-9]+|[a-zA-Z]|i+)\.$`)
+
 // convertToParagraphs converts TextContent to a slice of Paragraphs.
 func convertToParagraphs(text *slides.TextContent) []*Paragraph {
 	if text == nil || len(text.TextElements) == 0 {
@@ -149,9 +153,8 @@ func convertToParagraphs(text *slides.TextContent) []*Paragraph {
 				// Determine the type of bullet points based on glyph content
 				if element.ParagraphMarker.Bullet.Glyph != "" {
 					glyph := element.ParagraphMarker.Bullet.Glyph
-					// Check for numbered bullets (1, 2, 3, etc.)
-					if strings.ContainsAny(glyph, "0123456789") {
-						currentBullet = BulletNumber
+					if numberedBulletReg.MatchString(glyph) {
+						currentBullet = BulletNumbered
 					} else {
 						currentBullet = BulletDash
 					}

--- a/md/md.go
+++ b/md/md.go
@@ -888,7 +888,7 @@ func toBullet(m byte) deck.Bullet {
 	case '-', '+', '*':
 		return deck.BulletDash
 	case '.', ')':
-		return deck.BulletNumber
+		return deck.BulletNumbered
 	default:
 		return deck.BulletNone
 	}

--- a/slide.go
+++ b/slide.go
@@ -88,10 +88,9 @@ type Bullet string
 
 // Bullet constants for different bullet point types.
 const (
-	BulletNone   Bullet = ""
-	BulletDash   Bullet = "-"
-	BulletNumber Bullet = "1"
-	BulletAlpha  Bullet = "a"
+	BulletNone     Bullet = ""
+	BulletDash     Bullet = "-"
+	BulletNumbered Bullet = "1"
 )
 
 type MIMEType string
@@ -157,10 +156,8 @@ func (p *Paragraph) String() string {
 	switch p.Bullet {
 	case BulletDash:
 		result.WriteString("- ")
-	case BulletNumber:
+	case BulletNumbered:
 		result.WriteString("1. ")
-	case BulletAlpha:
-		result.WriteString("a. ")
 	}
 	for _, fragment := range p.Fragments {
 		if fragment == nil {

--- a/slide_string_test.go
+++ b/slide_string_test.go
@@ -136,21 +136,10 @@ func TestParagraphString(t *testing.T) {
 				Fragments: []*Fragment{
 					{Value: "Number bullet item"},
 				},
-				Bullet:  BulletNumber,
+				Bullet:  BulletNumbered,
 				Nesting: 0,
 			},
 			expected: "1. Number bullet item",
-		},
-		{
-			name: "paragraph with alpha bullet",
-			paragraph: &Paragraph{
-				Fragments: []*Fragment{
-					{Value: "Alpha bullet item"},
-				},
-				Bullet:  BulletAlpha,
-				Nesting: 0,
-			},
-			expected: "a. Alpha bullet item",
 		},
 		{
 			name: "paragraph with nesting level 1",
@@ -206,7 +195,7 @@ func TestParagraphString(t *testing.T) {
 				Fragments: []*Fragment{
 					{Value: "Nested numbered item"},
 				},
-				Bullet:  BulletNumber,
+				Bullet:  BulletNumbered,
 				Nesting: 1,
 			},
 			expected: "  1. Nested numbered item",
@@ -393,18 +382,12 @@ func TestBlockQuoteString(t *testing.T) {
 						Fragments: []*Fragment{
 							{Value: "Number bullet"},
 						},
-						Bullet: BulletNumber,
-					},
-					{
-						Fragments: []*Fragment{
-							{Value: "Alpha bullet"},
-						},
-						Bullet: BulletAlpha,
+						Bullet: BulletNumbered,
 					},
 				},
 				Nesting: 0,
 			},
-			expected: "> - Dash bullet\n> 1. Number bullet\n> a. Alpha bullet\n",
+			expected: "> - Dash bullet\n> 1. Number bullet\n",
 		},
 	}
 


### PR DESCRIPTION
HTML has regular lists (li) and ordered lists (ol), both of which can be expressed in Markdown.

In addition, the notation “a.” and “b.” is not specified in the Markdown specification and is not supported by goldmark. There are no extensions either. Therefore, the processing that parses this as the parsing specification in `package md` is unnecessary, so it has been removed.

(By the way, in HTML, you can use the type attribute of ol to display “a.” and “b.”)

In Google Slides, there are two types of bullets: regular and numbered. Alpha is just one way to express numbered bullets.

Therefore, we renamed BulletNumber to BulletNumbered, deleted BulletAlpha, and merged it into BulletNumbered.

This makes it easier to compare the information structure between Markdown and Google Slides.

Originally, BulletAlpha was never used in normal cases, so there are no compatibility changes in behavior.

(In Markdown, there was no such notation as “a.”, and there was no code to handle BulletAlpha when converting from Google Slides to Slide objects.)