### PR TITLE
chore: guide users to doc when HTTP client is not constructed

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -156,6 +156,9 @@ var applyCmd = &cobra.Command{
 		}
 		d, err := deck.New(ctx, opts...)
 		if err != nil {
+			if errors.Is(err, deck.HttpClientError) {
+				cmd.Println(deck.SetupInstructionMessage)
+			}
 			return err
 		}
 		if title != "" {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -28,6 +28,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/k1LoW/deck"
 	"github.com/k1LoW/deck/md"
+	"github.com/k1LoW/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -62,6 +63,9 @@ var exportCmd = &cobra.Command{
 		}
 		d, err := deck.New(ctx, opts...)
 		if err != nil {
+			if errors.Is(err, deck.HttpClientError) {
+				cmd.Println(deck.SetupInstructionMessage)
+			}
 			return err
 		}
 		f, err := os.Create(out)

--- a/cmd/lsLayouts.go
+++ b/cmd/lsLayouts.go
@@ -27,6 +27,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/k1LoW/deck"
 	"github.com/k1LoW/deck/md"
+	"github.com/k1LoW/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -59,6 +60,9 @@ var lsLayoutsCmd = &cobra.Command{
 		}
 		d, err := deck.New(ctx, opts...)
 		if err != nil {
+			if errors.Is(err, deck.HttpClientError) {
+				cmd.Println(deck.SetupInstructionMessage)
+			}
 			return err
 		}
 		layouts := d.ListLayouts()

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -27,6 +27,7 @@ import (
 	"github.com/k1LoW/deck"
 	"github.com/k1LoW/deck/config"
 	"github.com/k1LoW/deck/md"
+	"github.com/k1LoW/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -65,16 +66,17 @@ If the file doesn't exist, it will be created.`,
 			opts = append(opts, deck.WithFolderID(folderID))
 		}
 		var d *deck.Deck
+		var err_ error
 		if from != "" {
-			d, err = deck.CreateFrom(ctx, from, opts...)
-			if err != nil {
-				return err
-			}
+			d, err_ = deck.CreateFrom(ctx, from, opts...)
 		} else {
-			d, err = deck.Create(ctx, opts...)
-			if err != nil {
-				return err
+			d, err_ = deck.Create(ctx, opts...)
+		}
+		if err_ != nil {
+			if errors.Is(err_, deck.HttpClientError) {
+				cmd.Println(deck.SetupInstructionMessage)
 			}
+			return err_
 		}
 		if title != "" {
 			if err := d.UpdateTitle(ctx, title); err != nil {

--- a/deck.go
+++ b/deck.go
@@ -414,6 +414,7 @@ func (d *Deck) initialize(ctx context.Context) (err error) {
 	// Get client option (service account or OAuth2)
 	client, err := d.getHTTPClient(ctx)
 	if err != nil {
+		fmt.Println("Check https://github.com/k1LoW/deck?tab=readme-ov-file#setup for setup instructions")
 		return err
 	}
 

--- a/deck.go
+++ b/deck.go
@@ -400,6 +400,10 @@ func newDeck(ctx context.Context, opts ...Option) (*Deck, error) {
 	return d, err
 }
 
+var HttpClientError = errors.New("http client error")
+
+const SetupInstructionMessage = "Check https://github.com/k1LoW/deck?tab=readme-ov-file#setup for setup instructions"
+
 func (d *Deck) initialize(ctx context.Context) (err error) {
 	defer func() {
 		err = errors.WithStack(err)
@@ -414,8 +418,7 @@ func (d *Deck) initialize(ctx context.Context) (err error) {
 	// Get client option (service account or OAuth2)
 	client, err := d.getHTTPClient(ctx)
 	if err != nil {
-		fmt.Println("Check https://github.com/k1LoW/deck?tab=readme-ov-file#setup for setup instructions")
-		return err
+		return errors.Join(err, HttpClientError)
 	}
 
 	srv, err := slides.NewService(ctx, option.WithHTTPClient(client))


### PR DESCRIPTION
HTTP client construction fails mostly when GCP credential is not configured.
This guide will improve deck first-timer experience.