### PR TITLE
Add error for google.ConfigFromJSON in Deck.getOAuthConfig

### DIFF
--- a/client.go
+++ b/client.go
@@ -93,7 +93,11 @@ func (d *Deck) getOAuthConfig() (*oauth2.Config, error) {
 		return nil, err
 	}
 
-	return google.ConfigFromJSON(b, slides.PresentationsScope, slides.DriveScope)
+	c, err := google.ConfigFromJSON(b, slides.PresentationsScope, slides.DriveScope)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get oauth config from json: %w", err)
+	}
+	return c, nil
 }
 
 func (d *Deck) getDefaultHTTPClient(ctx context.Context) (_ *http.Client, err error) {


### PR DESCRIPTION
I wrongly added my OAuth secret itself to `credentials.json` and error was vague like below:

```bash
deck new deck.md --title "Talk about deck"
Error: failed to get HTTP client: invalid character '-' after top-level value
```

I couldn't tell the cause of it without reading the code.

This fixes the confusion to a certain extent by adding the error to `google.ConfigFromJSON`.

The error message will be like this:

```bash
Error: failed to get HTTP client: failed to get oauth config from json: invalid character '-' after top-level value
```