### PR TITLE
feat: add support for normalizing CRLF line endings

### DIFF
--- a/md/md.go
+++ b/md/md.go
@@ -128,6 +128,13 @@ func Parse(baseDir string, b []byte, cfg *config.Config) (_ *MD, err error) {
 	defer func() {
 		err = errors.WithStack(err)
 	}()
+
+	// Normalize line endings: CRLF -> LF, CR -> LF
+	if bytes.Contains(b, []byte("\r")) {
+		b = bytes.ReplaceAll(b, []byte("\r\n"), []byte("\n"))
+		b = bytes.ReplaceAll(b, []byte("\r"), []byte("\n"))
+	}
+
 	sep := []byte("---\n")
 
 	// Extract YAML frontmatter if present

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -373,3 +373,58 @@ ref: [deck repo](https://github.com/k1LoW/deck)
 		_, _ = Parse(".", in, nil)
 	})
 }
+
+// TestCRLFSupport tests that CRLF line endings are handled correctly
+// by comparing the parse results of LF and CRLF versions of the same file.
+func TestCRLFSupport(t *testing.T) {
+	// Parse LF version
+	lfData, err := os.ReadFile("../testdata/slide.md")
+	if err != nil {
+		t.Fatalf("failed to read LF file: %v", err)
+	}
+	lfMD, err := Parse("../testdata", lfData, nil)
+	if err != nil {
+		t.Fatalf("failed to parse LF file: %v", err)
+	}
+
+	// Parse CRLF version
+	crlfData, err := os.ReadFile("../testdata/slide.crlf.md")
+	if err != nil {
+		t.Fatalf("failed to read CRLF file: %v", err)
+	}
+	crlfMD, err := Parse("../testdata", crlfData, nil)
+	if err != nil {
+		t.Fatalf("failed to parse CRLF file: %v", err)
+	}
+
+	// Convert both to JSON for comparison
+	lfJSON, err := json.MarshalIndent(lfMD.Contents, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal LF contents: %v", err)
+	}
+
+	crlfJSON, err := json.MarshalIndent(crlfMD.Contents, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal CRLF contents: %v", err)
+	}
+
+	// Compare the results
+	if string(lfJSON) != string(crlfJSON) {
+		t.Errorf("CRLF and LF versions produce different results.\nLF result:\n%s\n\nCRLF result:\n%s", string(lfJSON), string(crlfJSON))
+	}
+
+	// Also test ParseFile function for CRLF file
+	crlfMDFromFile, err := ParseFile("../testdata/slide.crlf.md", nil)
+	if err != nil {
+		t.Fatalf("failed to parse CRLF file using ParseFile: %v", err)
+	}
+
+	crlfFromFileJSON, err := json.MarshalIndent(crlfMDFromFile.Contents, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal CRLF contents from ParseFile: %v", err)
+	}
+
+	if string(lfJSON) != string(crlfFromFileJSON) {
+		t.Errorf("ParseFile with CRLF and Parse with LF produce different results.\nLF Parse result:\n%s\n\nCRLF ParseFile result:\n%s", string(lfJSON), string(crlfFromFileJSON))
+	}
+}

--- a/testdata/slide.crlf.md
+++ b/testdata/slide.crlf.md
@@ -1,0 +1,70 @@
+# Title
+
+## Subtitle
+
+@k1LoW
+
+<!-- {"layout":"title"} -->
+
+---
+
+# Title
+
+<!-- 
+
+comment
+
+-->
+
+<!-- comment -->
+
+<!-- {"layout":"section"} -->
+
+---
+
+# Title
+
+- aA
+- b**B**
+- cC
+    - dD
+- *e*E
+    - fF
+        - gG
+1. h**H**
+1. **i**I
+
+ref: [deck repo](https://github.com/k1LoW/deck)
+
+---
+
+# 1
+
+## 2
+
+## 3
+
+body
+
+<!-- {"layout":"title-and-body"} -->
+
+---
+
+## 2
+
+# 1
+
+## 3
+
+a
+
+## 4
+
+b
+
+## 5
+
+c
+
+<!-- {"layout":"title-and-body-3col"} -->
+


### PR DESCRIPTION
ref: https://github.com/k1LoW/deck/issues/412

This pull request improves support for different line endings (CRLF and CR) in Markdown files, ensuring consistent parsing results regardless of the file's line ending style. It also adds comprehensive tests to validate this behavior.

**Line ending normalization:**

* Added logic to the `Parse` function in `md/md.go` to normalize all CRLF (`\r\n`) and CR (`\r`) line endings to LF (`\n`), ensuring consistent parsing across platforms.
