### PR TITLE
fix: simplify image comparison logic by removing MIME type check

### DIFF
--- a/image.go
+++ b/image.go
@@ -196,24 +196,23 @@ func (i *Image) Equivalent(ii *Image) bool {
 	if i.Checksum() == ii.Checksum() {
 		return true
 	}
-	if i.mimeType == MIMETypeImageJPEG {
-		// Only JPEG images are compressed on the Google Slides side,
-		// so we use Perceptual Hashing for comparison
-		aHash, err := i.PHash()
-		if err != nil {
-			return false
-		}
-		bHash, err := ii.PHash()
-		if err != nil {
-			return false
-		}
-		distance, err := aHash.Distance(bHash)
-		if err != nil {
-			return false
-		}
-		if distance < 5 { // threshold for similarity
-			return true
-		}
+
+	// Images are compressed on the Google Slides side (especially JPEG, large images),
+	// so we use Perceptual Hashing for comparison
+	aHash, err := i.PHash()
+	if err != nil {
+		return false
+	}
+	bHash, err := ii.PHash()
+	if err != nil {
+		return false
+	}
+	distance, err := aHash.Distance(bHash)
+	if err != nil {
+		return false
+	}
+	if distance < 5 { // threshold for similarity
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
Since we discovered that Google Slides compresses not only JPEGs but also large images, we will perform the pHash comparison on all images.

This pull request refines the logic for comparing image equivalence in the `Image` struct, specifically in the `Equivalent` method. The main improvement is broadening the use of perceptual hashing to compare all images, not just JPEGs, to better account for compression artifacts introduced by Google Slides.

Image equivalence logic improvements:

* The perceptual hashing comparison is now applied to all image types, rather than being restricted to JPEGs, making the equivalence check more robust against Google Slides compression for a wider range of images.
* Removed the unnecessary conditional block that limited perceptual hashing to JPEG images, simplifying the code and ensuring consistent behavior.
