### PR TITLE
fix: resolve govet inline and modernize lint errors

### DIFF
--- a/action.go
+++ b/action.go
@@ -654,8 +654,7 @@ func generateDeleteActions(before *Slides, mapping *map[int]int) []*action {
 	var actions []*action
 
 	// Delete from back to maintain index consistency
-	for i := len(*before) - 1; i >= 0; i-- {
-		slide := (*before)[i]
+	for i, slide := range slices.Backward(*before) {
 		if slide.delete {
 			// Generate delete action (add in deletion order)
 			actions = append(actions, &action{

--- a/apply.go
+++ b/apply.go
@@ -756,11 +756,6 @@ func countString(s string) int {
 	return length
 }
 
-//go:fix inline
-func ptrInt64(i int64) *int64 {
-	return new(i)
-}
-
 func convertBullet(b Bullet) string {
 	switch b {
 	case BulletDash:

--- a/table.go
+++ b/table.go
@@ -432,7 +432,7 @@ func (d *Deck) createTableContentRequests(tableObjectID string, table *Table) ([
 							Style:        req.Style,
 							TextRange: &slides.Range{
 								Type:       "FIXED_RANGE",
-								StartIndex: ptrInt64(0),
+								StartIndex: new(int64),
 								EndIndex:   new(textLength),
 							},
 							Fields: req.Fields,


### PR DESCRIPTION
`make lint` was failing on two issues:

- `table.go:435` — govet `inline` flagged `ptrInt64(0)` because `ptrInt64` in `apply.go` is annotated with `//go:fix inline`.
- `action.go:657` — modernize `slicesbackward` flagged the manual reverse index loop in `generateDeleteActions`.

Changes:

* Inline the single `ptrInt64(0)` callsite in `table.go` to `new(int64)` and remove the now-unused helper from `apply.go`.
* Rewrite the backward loop in `generateDeleteActions` using `slices.Backward`.

Verified with `make lint` (0 issues) and `go test ./...` (all packages pass).