### PR TITLE
fix: preserve frozen slides when slide count changes

### DIFF
--- a/action.go
+++ b/action.go
@@ -53,17 +53,32 @@ func generateActions(before, after Slides) (_ []*action, err error) {
 	beforeCopy := copySlides(before)
 	afterCopy := copySlides(after)
 
+	// Resolve which before slide each frozen after slide corresponds to, and
+	// substitute the counterpart's current content into after. The
+	// similarity-based pipeline below then sees the pair as identical and
+	// generates no update/delete actions for it, regardless of slide count
+	// changes (https://github.com/k1LoW/deck/issues/479).
+	frozenPairs := resolveFrozenSlides(beforeCopy, afterCopy)
+	for i, afterSlide := range afterCopy {
+		if !afterSlide.Freeze {
+			continue
+		}
+		if beforeIdx, ok := frozenPairs[i]; ok {
+			preserved := copySlide(beforeCopy[beforeIdx])
+			preserved.Freeze = true
+			afterCopy[i] = preserved
+		} else {
+			// A frozen slide without a counterpart is created from its
+			// markdown content. Freeze must be cleared because it would
+			// suppress content application on append.
+			afterSlide.Freeze = false
+		}
+	}
+
 	// Adjust slide count
 	adjustedBefore, adjustedAfter, err := adjustSlideCount(beforeCopy, afterCopy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to adjust slide count: %w", err)
-	}
-
-	// Prevent actions from being generated from indexes that should be frozen.
-	for i, afterSlide := range adjustedAfter {
-		if afterSlide.Freeze {
-			adjustedBefore[i] = copySlide(afterSlide)
-		}
 	}
 
 	// Map slides algorithm

--- a/action_test.go
+++ b/action_test.go
@@ -1659,8 +1659,8 @@ var tests = []struct {
 			},
 			{
 				Layout:      "title",
-				Titles:      []string{"Slide C"},
-				TitleBodies: toBodies([]string{"Slide C"}),
+				Titles:      []string{"Slide B"},
+				TitleBodies: toBodies([]string{"Slide B"}),
 			},
 		},
 	},
@@ -1696,6 +1696,243 @@ var tests = []struct {
 				Layout:      "title",
 				Titles:      []string{"Slide B"},
 				TitleBodies: toBodies([]string{"Slide B"}),
+			},
+		},
+	},
+	{
+		name: "freeze slide with insert before frozen slide",
+		before: Slides{
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 1"},
+				TitleBodies: toBodies([]string{"Slide 1"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 2"},
+				TitleBodies: toBodies([]string{"Slide 2"}),
+			},
+		},
+		after: Slides{
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 1"},
+				TitleBodies: toBodies([]string{"Slide 1"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide NEW"},
+				TitleBodies: toBodies([]string{"Slide NEW"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 2"},
+				TitleBodies: toBodies([]string{"Slide 2"}),
+				Freeze:      true,
+			},
+		},
+		want: Slides{
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 1"},
+				TitleBodies: toBodies([]string{"Slide 1"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide NEW"},
+				TitleBodies: toBodies([]string{"Slide NEW"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 2"},
+				TitleBodies: toBodies([]string{"Slide 2"}),
+			},
+		},
+	},
+	{
+		name: "freeze slide with delete before frozen slide",
+		before: Slides{
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 1"},
+				TitleBodies: toBodies([]string{"Slide 1"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 2"},
+				TitleBodies: toBodies([]string{"Slide 2"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 3"},
+				TitleBodies: toBodies([]string{"Slide 3"}),
+			},
+		},
+		after: Slides{
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 1"},
+				TitleBodies: toBodies([]string{"Slide 1"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 3"},
+				TitleBodies: toBodies([]string{"Slide 3"}),
+				Freeze:      true,
+			},
+		},
+		want: Slides{
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 1"},
+				TitleBodies: toBodies([]string{"Slide 1"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 3"},
+				TitleBodies: toBodies([]string{"Slide 3"}),
+			},
+		},
+	},
+	{
+		// The actual content of the frozen slide has diverged from its
+		// markdown source (the typical reason for freezing). The diverged
+		// content must survive an insertion before the frozen slide.
+		name: "freeze diverged slide with insert before frozen slide",
+		before: Slides{
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 1"},
+				TitleBodies: toBodies([]string{"Slide 1"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 2 edited manually"},
+				TitleBodies: toBodies([]string{"Slide 2 edited manually"}),
+			},
+		},
+		after: Slides{
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 1"},
+				TitleBodies: toBodies([]string{"Slide 1"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide NEW"},
+				TitleBodies: toBodies([]string{"Slide NEW"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 2"},
+				TitleBodies: toBodies([]string{"Slide 2"}),
+				Freeze:      true,
+			},
+		},
+		want: Slides{
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 1"},
+				TitleBodies: toBodies([]string{"Slide 1"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide NEW"},
+				TitleBodies: toBodies([]string{"Slide NEW"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 2 edited manually"},
+				TitleBodies: toBodies([]string{"Slide 2 edited manually"}),
+			},
+		},
+	},
+	{
+		name: "freeze all slides with insert between",
+		before: Slides{
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide P"},
+				TitleBodies: toBodies([]string{"Slide P"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide Q"},
+				TitleBodies: toBodies([]string{"Slide Q"}),
+			},
+		},
+		after: Slides{
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide P"},
+				TitleBodies: toBodies([]string{"Slide P"}),
+				Freeze:      true,
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide NEW"},
+				TitleBodies: toBodies([]string{"Slide NEW"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide Q"},
+				TitleBodies: toBodies([]string{"Slide Q"}),
+				Freeze:      true,
+			},
+		},
+		want: Slides{
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide P"},
+				TitleBodies: toBodies([]string{"Slide P"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide NEW"},
+				TitleBodies: toBodies([]string{"Slide NEW"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide Q"},
+				TitleBodies: toBodies([]string{"Slide Q"}),
+			},
+		},
+	},
+	{
+		// A frozen slide that has no counterpart in the presentation is
+		// created from its markdown content. Freezing protects it from the
+		// next apply onward.
+		name: "freeze new slide without counterpart",
+		before: Slides{
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 1"},
+				TitleBodies: toBodies([]string{"Slide 1"}),
+			},
+		},
+		after: Slides{
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 1"},
+				TitleBodies: toBodies([]string{"Slide 1"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide F"},
+				TitleBodies: toBodies([]string{"Slide F"}),
+				Freeze:      true,
+			},
+		},
+		want: Slides{
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide 1"},
+				TitleBodies: toBodies([]string{"Slide 1"}),
+			},
+			{
+				Layout:      "title",
+				Titles:      []string{"Slide F"},
+				TitleBodies: toBodies([]string{"Slide F"}),
 			},
 		},
 	},

--- a/freeze.go
+++ b/freeze.go
@@ -1,0 +1,110 @@
+// freeze.go contains the logic that resolves which existing (before) slide
+// each frozen (after) slide corresponds to.
+package deck
+
+import "slices"
+
+// frozenMatchFloor is the minimum alignment score granted to a frozen after
+// slide against any before slide. Frozen slides are expected to have diverged
+// from their markdown source (that is often why they are frozen), so content
+// similarity alone cannot identify their counterpart. The floor lets the
+// order-preserving alignment adopt a counterpart by relative position, while
+// staying below genuine content matches (e.g. layout+title scores 130) so
+// that non-frozen slides win their anchors first.
+const frozenMatchFloor = 100
+
+// resolveFrozenSlides determines which before slide each frozen after slide
+// corresponds to. It returns a map with after index as key and before index
+// as value. Frozen after slides without a counterpart are absent from the map.
+//
+// Frozen slides cannot be matched by content similarity because their actual
+// content may have diverged from the markdown source. Instead, non-frozen
+// slides act as anchors through their content similarity, and frozen slides
+// are matched by relative order between those anchors using an
+// order-preserving alignment (Needleman-Wunsch style). A second pass matches
+// the remaining frozen slides against unmatched before slides by similarity,
+// which covers frozen slides moved across anchors.
+func resolveFrozenSlides(before, after Slides) map[int]int {
+	resolved := make(map[int]int)
+	if len(before) == 0 || !slices.ContainsFunc(after, func(s *Slide) bool { return s.Freeze }) {
+		return resolved
+	}
+
+	m := len(before)
+	n := len(after)
+	// dp[i][j] is the best alignment score between before[:i] and after[:j].
+	// Gaps (unmatched slides on either side) carry no penalty.
+	dp := make([][]int, m+1)
+	for i := range dp {
+		dp[i] = make([]int, n+1)
+	}
+	for i := 1; i <= m; i++ {
+		for j := 1; j <= n; j++ {
+			dp[i][j] = max(
+				dp[i-1][j-1]+frozenAlignScore(before[i-1], after[j-1]),
+				dp[i-1][j],
+				dp[i][j-1],
+			)
+		}
+	}
+
+	// Backtrack, preferring matches over gaps so that frozen slides adopt a
+	// counterpart whenever doing so does not lower the total score.
+	matchedBefore := make([]bool, m)
+	i, j := m, n
+	for i > 0 && j > 0 {
+		score := frozenAlignScore(before[i-1], after[j-1])
+		switch {
+		case score > 0 && dp[i][j] == dp[i-1][j-1]+score:
+			if after[j-1].Freeze {
+				resolved[j-1] = i - 1
+			}
+			matchedBefore[i-1] = true
+			i--
+			j--
+		case dp[i][j] == dp[i-1][j]:
+			i--
+		default:
+			j--
+		}
+	}
+
+	// Second pass: frozen slides that the order-preserving alignment could
+	// not match (e.g. frozen slides moved across anchors) adopt the most
+	// similar unmatched before slide, as long as the content still resembles
+	// the markdown source.
+	for j, afterSlide := range after {
+		if !afterSlide.Freeze {
+			continue
+		}
+		if _, ok := resolved[j]; ok {
+			continue
+		}
+		bestIdx := -1
+		bestScore := 0
+		for i, beforeSlide := range before {
+			if matchedBefore[i] {
+				continue
+			}
+			if score := getSimilarity(beforeSlide, afterSlide); score > bestScore {
+				bestIdx = i
+				bestScore = score
+			}
+		}
+		if bestIdx >= 0 && bestScore >= frozenMatchFloor {
+			resolved[j] = bestIdx
+			matchedBefore[bestIdx] = true
+		}
+	}
+
+	return resolved
+}
+
+// frozenAlignScore is the alignment score used by resolveFrozenSlides.
+func frozenAlignScore(beforeSlide, afterSlide *Slide) int {
+	score := getSimilarity(beforeSlide, afterSlide)
+	if afterSlide.Freeze {
+		return max(score, frozenMatchFloor)
+	}
+	return score
+}

--- a/freeze_test.go
+++ b/freeze_test.go
@@ -1,0 +1,134 @@
+package deck
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestResolveFrozenSlides(t *testing.T) {
+	tests := []struct {
+		name   string
+		before Slides
+		after  Slides
+		want   map[int]int
+	}{
+		{
+			name:   "empty slides",
+			before: Slides{},
+			after:  Slides{},
+			want:   map[int]int{},
+		},
+		{
+			name: "no frozen slides",
+			before: Slides{
+				{Layout: "title", Titles: []string{"Slide 1"}},
+			},
+			after: Slides{
+				{Layout: "title", Titles: []string{"Slide 1"}},
+			},
+			want: map[int]int{},
+		},
+		{
+			name:   "frozen slide with empty before",
+			before: Slides{},
+			after: Slides{
+				{Layout: "title", Titles: []string{"Slide 1"}, Freeze: true},
+			},
+			want: map[int]int{},
+		},
+		{
+			name: "insert before frozen slide",
+			before: Slides{
+				{Layout: "title", Titles: []string{"Slide 1"}},
+				{Layout: "title", Titles: []string{"Slide 2"}},
+			},
+			after: Slides{
+				{Layout: "title", Titles: []string{"Slide 1"}},
+				{Layout: "title", Titles: []string{"Slide NEW"}},
+				{Layout: "title", Titles: []string{"Slide 2"}, Freeze: true},
+			},
+			want: map[int]int{2: 1},
+		},
+		{
+			name: "delete before frozen slide",
+			before: Slides{
+				{Layout: "title", Titles: []string{"Slide 1"}},
+				{Layout: "title", Titles: []string{"Slide 2"}},
+				{Layout: "title", Titles: []string{"Slide 3"}},
+			},
+			after: Slides{
+				{Layout: "title", Titles: []string{"Slide 1"}},
+				{Layout: "title", Titles: []string{"Slide 3"}, Freeze: true},
+			},
+			want: map[int]int{1: 2},
+		},
+		{
+			// The frozen slide's actual content has diverged from its
+			// markdown source. It must still adopt a counterpart by
+			// relative order between anchors.
+			name: "diverged frozen slide adopts counterpart by order",
+			before: Slides{
+				{Layout: "title", Titles: []string{"Slide 1"}},
+				{Layout: "title", Titles: []string{"Slide 2 edited manually"}},
+			},
+			after: Slides{
+				{Layout: "title", Titles: []string{"Slide 1"}},
+				{Layout: "title", Titles: []string{"Slide 2"}, Freeze: true},
+			},
+			want: map[int]int{1: 1},
+		},
+		{
+			// The frozen slide crosses the anchor "Slide C" in the desired
+			// order. The order-preserving alignment cannot express this
+			// move, so the second pass matches it by similarity.
+			name: "frozen slide moved across anchors",
+			before: Slides{
+				{Layout: "title", Titles: []string{"Slide A"}},
+				{Layout: "title", Titles: []string{"Slide B"}},
+				{Layout: "title", Titles: []string{"Slide C"}},
+			},
+			after: Slides{
+				{Layout: "title", Titles: []string{"Slide A"}},
+				{Layout: "title", Titles: []string{"Slide C"}},
+				{Layout: "title", Titles: []string{"Slide B"}, Freeze: true},
+			},
+			want: map[int]int{2: 1},
+		},
+		{
+			// Every before slide is claimed by a non-frozen anchor, so the
+			// frozen slide has no counterpart and is absent from the result.
+			name: "frozen slide without counterpart",
+			before: Slides{
+				{Layout: "title", Titles: []string{"Slide 1"}},
+			},
+			after: Slides{
+				{Layout: "title", Titles: []string{"Slide 1"}},
+				{Layout: "title", Titles: []string{"Slide F"}, Freeze: true},
+			},
+			want: map[int]int{},
+		},
+		{
+			name: "all slides frozen with insert between",
+			before: Slides{
+				{Layout: "title", Titles: []string{"Slide P"}},
+				{Layout: "title", Titles: []string{"Slide Q"}},
+			},
+			after: Slides{
+				{Layout: "title", Titles: []string{"Slide P"}, Freeze: true},
+				{Layout: "title", Titles: []string{"Slide NEW"}},
+				{Layout: "title", Titles: []string{"Slide Q"}, Freeze: true},
+			},
+			want: map[int]int{0: 0, 2: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveFrozenSlides(tt.before, tt.after)
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
ref: https://github.com/k1LoW/deck/issues/479

## Problem

When a slide with `freeze: true` exists and the total number of slides changes by inserting or deleting slides, the frozen slide disappears or a wrong slide is preserved.

`generateActions` resolved freeze by overwriting `before[i]` with `after[i]` after slide-count padding, assuming that index `i` in before corresponds to index `i` in after. Inserting or deleting slides before a frozen slide breaks that assumption. The overwrite corrupted the padded slides and their internal new/delete marks, so the Hungarian mapping ended up updating or deleting the very slide that should have been preserved.

## Approach (frozen slides as order-constrained wildcards)

Frozen slides cannot be matched by content similarity because their actual content may have diverged from the markdown source, which is often the reason for freezing in the first place. So the freeze resolution is moved out of the index-based pre-processing.

- `resolveFrozenSlides` (new `freeze.go`) determines the counterpart of each frozen slide with an order-preserving alignment (Needleman-Wunsch style). Non-frozen slides act as anchors through content similarity, and frozen slides are matched by relative order between those anchors, with a score floor so that content divergence does not prevent matching. A second pass matches remaining frozen slides against unmatched before slides by similarity, covering frozen slides moved across anchors.
- `generateActions` substitutes the counterpart's current content into `after`, so the existing similarity-based pipeline sees the pair as identical and generates no update or delete actions for it, while move actions still work. The former pre-processing that overwrote `before[i]` is removed.
- A frozen slide without a counterpart (a brand-new page marked `freeze: true`) is created from its markdown content. Freezing protects it from the next apply onward.

## Behavior change

The existing `freeze slide moved` test expected `[A, C, C]`, where the frozen slide B was overwritten by an update and C ended up duplicated. The expectation is now `[A, C, B]`. The frozen slide keeps its actual content and is moved to the desired position, which matches the intent of freezing.

## Tests

- Adds the two failing cases from the issue report (insert and delete before a frozen slide).
- Adds cases for diverged frozen content with insertion, all slides frozen with insertion between them, and a frozen slide without a counterpart.
- Adds unit tests for `resolveFrozenSlides` in `freeze_test.go`.
- `go test ./...`, `golangci-lint run ./...`, and a 30s `FuzzGenerateActions` run all pass.

## Known limitations

This PR narrows the freeze failure surface to the two issue-reported cases and their close variants, but the `Frozen-as-Anchor` approach still infers the markdown-page ⟷ existing-slide correspondence rather than recording it. The following combinations remain ambiguous and can produce a surprising result.

1. **All slides frozen with a reorder.** `before = [A, B, C]`, `after = [C(freeze), B(freeze), A(freeze)]`. With no non-frozen anchors, the order-preserving alignment matches by position, so each slide's content stays put and the reorder intent is silently lost.
2. **Frozen slide whose layout has diverged, next to another same-layout-diverged sibling.** `before = [A(title), B(custom layout, hand-edited), C(title)]`, `after = [A(title), B(freeze, title)]`. `getSimilarity` returns 0 on layout mismatch, so both `B` and `C` land at the frozen floor with the same score; the DP tie-break can pick `C` as the counterpart and the intended `B` is then removed as a delete-marker.
3. **Multiple frozen slides moved across anchors.** The second pass in `resolveFrozenSlides` is a greedy per-frozen-slide argmax. When several frozen slides compete for the same before slide, the winner depends on iteration order rather than joint optimality.

These are all instances of the residual identity gap noted in the architecture analysis; a follow-up along the "Stable Slide Identity" direction is needed to close them structurally.
